### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test_coverage.yml
+++ b/.github/workflows/test_coverage.yml
@@ -6,6 +6,8 @@ on:
 
 jobs:
   test:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/openfactoryio/openfactory-core/security/code-scanning/1](https://github.com/openfactoryio/openfactory-core/security/code-scanning/1)

In general, the problem is fixed by declaring an explicit `permissions` block in the workflow (either at the root or per-job) that grants only the scopes required. For this job, most steps only need read access to the repository contents, but the final step that commits and pushes the coverage badge requires `contents: write`. Therefore, the job should have `permissions: contents: write` declared explicitly.

The best fix with minimal impact is to add a `permissions` section under the `test` job in `.github/workflows/test_coverage.yml`. This documents and constrains the GITHUB_TOKEN scope, and ensures that if the workflow is copied elsewhere or default settings change, it will still have just the necessary access. No imports or extra definitions are needed; we only modify the YAML. Specifically, add:

```yaml
permissions:
  contents: write
```

between the job name (`test:`) and `runs-on:`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
