### PR TITLE
Add bootstrap_servers in register_asset of MTConnectConnector class

### DIFF
--- a/openfactory/connectors/mtconnect/mtc_connector.py
+++ b/openfactory/connectors/mtconnect/mtc_connector.py
@@ -75,7 +75,8 @@ class MTConnectConnector(Connector):
 
         # Register device asset
         register_asset(device.uuid, uns=device.uns, asset_type="Device",
-                       ksqlClient=self.ksql, docker_service="")
+                       ksqlClient=self.ksql, bootstrap_servers=self.bootstrap_servers,
+                       docker_service="")
 
         # Deploy MTConnect agent (which itself deploys adapter if needed)
         agent_deployer = MTConnectAgentDeployer(device, yaml_config_file,

--- a/tests/openfactory/connectors/mtconnect/test_mtc_connector.py
+++ b/tests/openfactory/connectors/mtconnect/test_mtc_connector.py
@@ -67,6 +67,7 @@ class TestMTConnectConnector(unittest.TestCase):
             uns=self.device.uns,
             asset_type="Device",
             ksqlClient=self.connector.ksql,
+            bootstrap_servers="kafka:9092",
             docker_service=""
         )
 


### PR DESCRIPTION
Add `bootstrap_servers` argument in `register_asset` of the `MTConnectConnector` class.