### PR TITLE
164 make bootstrap servers optional in baseasset if environment variable kafka broker is set

### DIFF
--- a/openfactory/assets/asset_base.py
+++ b/openfactory/assets/asset_base.py
@@ -52,13 +52,13 @@ class BaseAsset:
     ASSET_ID = None
     ASSET_CONSUMER_CLASS = None
 
-    def __init__(self, ksqlClient: KSQLDBClient, bootstrap_servers: str, asset_router_url: str | None = None) -> None:
+    def __init__(self, ksqlClient: KSQLDBClient, bootstrap_servers: str | None = None, asset_router_url: str | None = None) -> None:
         """
         Initializes the Asset with metadata.
 
         Args:
             ksqlClient (KSQLDBClient): Client for interacting with ksqlDB.
-            bootstrap_servers (str): Kafka bootstrap server address.
+            bootstrap_servers (str | None): Kafka bootstrap server address.
             asset_router_url (str | None): Asset Router URL from the OpenFactory Fan-Out-Layer.
 
         Raises:
@@ -67,12 +67,15 @@ class BaseAsset:
                 are missing or invalid.
             TypeError: If ``ASSET_CONSUMER_CLASS`` is not a subclass of
                 ``KafkaAssetConsumer`` or ``KafkaAssetUNSConsumer``.
+            OFAException: If ``bootstrap_servers`` is not provided and the
+                ``KAFKA_BROKER`` environment variable is not set.
             OFAException: If ``asset_router_url`` is not provided and the
                 ``ASSET_ROUTER_URL`` environment variable is not set.
 
         Note:
+          - If ``bootstrap_servers`` is not explicitly provided, the constructor will attempt to read it from the ``KAFKA_BROKER`` environment variable.
           - If ``asset_router_url`` is not explicitly provided, the constructor will attempt to read it from the ``ASSET_ROUTER_URL`` environment variable.
-          - When used in an :class:`OpenFactoryApp <openfactory.apps.ofaapp.OpenFactoryApp>` deployed on the OpenFactory cluster, the environment variable ``ASSET_ROUTER_URL`` will be set.
+          - When used in an :class:`OpenFactoryApp <openfactory.apps.ofaapp.OpenFactoryApp>` deployed on the OpenFactory cluster, the environment variables ``KAFKA_BROKER`` and ``ASSET_ROUTER_URL`` will be set.
         """
         if not hasattr(self, 'KSQL_ASSET_TABLE') or self.KSQL_ASSET_TABLE is None:
             raise ValueError("KSQL_ASSET_TABLE must be set before initializing the Asset.")
@@ -86,15 +89,23 @@ class BaseAsset:
             raise TypeError("ASSET_CONSUMER_CLASS must be a subclass of KafkaAssetConsumer or KafkaAssetUNSConsumer.")
 
         super().__setattr__('ksql', ksqlClient)
-        super().__setattr__('bootstrap_servers', bootstrap_servers)
         super().__setattr__('loop_thread', AsyncLoopThread())
         super().__setattr__('subscribers', {})
+
+        if bootstrap_servers is None:
+            bootstrap_servers = os.getenv("KAFKA_BROKER")
+        if not bootstrap_servers:
+            raise OFAException(
+                "OpenFactory BaseAsset requires 'bootstrap_servers' to be provided "
+                "either explicitly or via the KAFKA_BROKER environment variable."
+            )
+        super().__setattr__('bootstrap_servers', bootstrap_servers)
 
         if asset_router_url is None:
             asset_router_url = os.getenv("ASSET_ROUTER_URL")
         if not asset_router_url:
             raise OFAException(
-                "OpenFactory Asset requires 'asset_router_url' to be provided "
+                "OpenFactory BaseAsset requires 'asset_router_url' to be provided "
                 "either explicitly or via the ASSET_ROUTER_URL environment variable."
             )
         super().__setattr__('asset_router_url', asset_router_url)

--- a/openfactory/assets/asset_class.py
+++ b/openfactory/assets/asset_class.py
@@ -81,7 +81,8 @@ class Asset(BaseAsset):
 
     def __init__(self, asset_uuid: str,
                  ksqlClient: KSQLDBClient,
-                 bootstrap_servers: str, asset_router_url: str | None = None) -> None:
+                 bootstrap_servers: str | None = None,
+                 asset_router_url: str | None = None) -> None:
         """
         Initializes the Asset with metadata and a Kafka producer.
 
@@ -92,12 +93,15 @@ class Asset(BaseAsset):
             asset_router_url (str | None): Asset Router URL from the OpenFactory Fan-Out-Layer.
 
         Raises:
+            OFAException: If ``bootstrap_servers`` is not provided and the
+                ``KAFKA_BROKER`` environment variable is not set.
             OFAException: If ``asset_router_url`` is not provided and the
                 ``ASSET_ROUTER_URL`` environment variable is not set.
 
         Note:
+          - If ``bootstrap_servers`` is not explicitly provided, the constructor will attempt to read it from the ``KAFKA_BROKER`` environment variable.
           - If ``asset_router_url`` is not explicitly provided, the constructor will attempt to read it from the ``ASSET_ROUTER_URL`` environment variable.
-          - When used in an :class:`OpenFactoryApp <openfactory.apps.ofaapp.OpenFactoryApp>` deployed on the OpenFactory cluster, the environment variable ``ASSET_ROUTER_URL`` will be set.
+          - When used in an :class:`OpenFactoryApp <openfactory.apps.ofaapp.OpenFactoryApp>` deployed on the OpenFactory cluster, the environment variables ``KAFKA_BROKER`` and ``ASSET_ROUTER_URL`` will be set.
         """
         object.__setattr__(self, 'ASSET_ID', asset_uuid)
         super().__init__(ksqlClient, bootstrap_servers, asset_router_url)

--- a/openfactory/assets/asset_uns_class.py
+++ b/openfactory/assets/asset_uns_class.py
@@ -85,7 +85,8 @@ class AssetUNS(BaseAsset):
     ASSET_CONSUMER_CLASS = KafkaAssetUNSConsumer
 
     def __init__(self, uns_id: str,
-                 ksqlClient: KSQLDBClient, bootstrap_servers: str,
+                 ksqlClient: KSQLDBClient,
+                 bootstrap_servers: str | None = None,
                  asset_router_url: str | None = None) -> None:
         """
         Initializes the Asset with metadata and a Kafka producer.
@@ -97,12 +98,15 @@ class AssetUNS(BaseAsset):
             asset_router_url (str | None): Asset Router URL from the OpenFactory Fan-Out-Layer.
 
         Raises:
+            OFAException: If ``bootstrap_servers`` is not provided and the
+                ``KAFKA_BROKER`` environment variable is not set.
             OFAException: If ``asset_router_url`` is not provided and the
                 ``ASSET_ROUTER_URL`` environment variable is not set.
 
         Note:
+          - If ``bootstrap_servers`` is not explicitly provided, the constructor will attempt to read it from the ``KAFKA_BROKER`` environment variable.
           - If ``asset_router_url`` is not explicitly provided, the constructor will attempt to read it from the ``ASSET_ROUTER_URL`` environment variable.
-          - When used in an :class:`OpenFactoryApp <openfactory.apps.ofaapp.OpenFactoryApp>` deployed on the OpenFactory cluster, the environment variable ``ASSET_ROUTER_URL`` will be set.
+          - When used in an :class:`OpenFactoryApp <openfactory.apps.ofaapp.OpenFactoryApp>` deployed on the OpenFactory cluster, the environment variables ``KAFKA_BROKER`` and ``ASSET_ROUTER_URL`` will be set.
         """
         object.__setattr__(self, 'ASSET_ID', uns_id)
         super().__init__(ksqlClient, bootstrap_servers, asset_router_url)

--- a/tests/openfactory/assets/test_baseasset.py
+++ b/tests/openfactory/assets/test_baseasset.py
@@ -89,6 +89,31 @@ class TestBaseAsset(TestCase):
 
         self.assertIn("ASSET_ROUTER_URL", str(ctx.exception))
 
+    def test_bootstrap_servers_explicit(self, MockAssetProducer):
+        """ Test explicite definition of bootstrap_servers """
+        asset = ValidAsset(
+            "some_id",
+            self.ksql_mock,
+            bootstrap_servers="mocked_kafka_broker"
+        )
+
+        self.assertEqual(asset.bootstrap_servers, "mocked_kafka_broker")
+
+    @patch.dict("os.environ", {"KAFKA_BROKER": "mocked-broker"})
+    def test_bootstrap_servers_from_env(self, MockAssetProducer):
+        """ Test environment variable fallback for bootstrap_servers """
+        asset = ValidAsset("some_id", self.ksql_mock, bootstrap_servers=None)
+
+        self.assertEqual(asset.bootstrap_servers, "mocked-broker")
+
+    @patch.dict("os.environ", {}, clear=True)
+    def test_bootstrap_servers_missing_raises(self, MockAssetProducer):
+        """ Test missing bootstrap_servers and missing KAFKA_BROKER env var raises """
+        with self.assertRaises(OFAException) as ctx:
+            ValidAsset("some_id", self.ksql_mock, bootstrap_servers=None)
+
+        self.assertIn("KAFKA_BROKER", str(ctx.exception))
+
     def test_missing_ksql_asset_table(self, MockAssetProducer):
         """ Test missing KSQL_ASSET_TABLE raise error """
         class MissingTable(ValidAsset):


### PR DESCRIPTION
Make `bootstrap_servers` optional in `BaseAsset` if environment variable `KAFKA_BROKER` is set