### PR TITLE
163 decorator ofa method does missbehave

### DIFF
--- a/openfactory/apps/decorators.py
+++ b/openfactory/apps/decorators.py
@@ -73,6 +73,12 @@ def ofa_method(
                 ):
                     ...
     """
+    if callable(name):
+        raise TypeError(
+            "@ofa_method must be called with parentheses. "
+            f"Did you mean '@ofa_method()' on '{name.__name__}'?"
+        )
+
     def decorator(func: Callable) -> Callable:
         sig = inspect.signature(func)
         params = sig.parameters

--- a/tests/openfactory/apps/test_ofa_method.py
+++ b/tests/openfactory/apps/test_ofa_method.py
@@ -8,6 +8,18 @@ class TestOFAMethodDecorator(unittest.TestCase):
     Unit tests for @ofa_method decorator
     """
 
+    def test_rejects_missing_parentheses(self):
+        """ Using @ofa_method without parentheses should raise TypeError. """
+
+        with self.assertRaises(TypeError) as ctx:
+
+            class Dummy:
+                @ofa_method  # missing ()
+                def move(self, x: float):
+                    pass
+
+        self.assertIn("must be called with parentheses", str(ctx.exception))
+
     def test_metadata_is_attached(self):
         """ Decorator should attach _ofa_method_metadata to function. """
 


### PR DESCRIPTION
Raises error when `@ofa_method` is used instead of `@ofa_method()` for decorator defining OpenFactory methods in `OpenFactoryApp`.