### PR TITLE
183 test mode flag

### DIFF
--- a/openfactory/apps/ofaapp.py
+++ b/openfactory/apps/ofaapp.py
@@ -106,7 +106,8 @@ class OpenFactoryApp(Asset, metaclass=OpenFactoryAppMeta):
                  ksqlClient: KSQLDBClient,
                  bootstrap_servers: str | None = None,
                  asset_router_url: str | None = None,
-                 loglevel: str = 'INFO'):
+                 loglevel: str = 'INFO',
+                 test_mode: bool = False):
         """
         Initializes the OpenFactory application.
 
@@ -120,6 +121,7 @@ class OpenFactoryApp(Asset, metaclass=OpenFactoryAppMeta):
             bootstrap_servers (str | None): Kafka bootstrap server address.
             asset_router_url (str | None): Asset Router URL from the OpenFactory Fan-Out-Layer.
             loglevel (str): Logging level for the app (e.g., ``INFO``, ``DEBUG``). Defaults to ``INFO``.
+            test_mode (bool): If True, disables live Kafka/ksql interaction (useful for unit tests).
 
         Note:
             - If ``bootstrap_servers`` is not explicitly provided, the constructor will attempt to read it from the ``KAFKA_BROKER`` environment variable.
@@ -134,7 +136,8 @@ class OpenFactoryApp(Asset, metaclass=OpenFactoryAppMeta):
         # get APP-UUID from environment (set during deployement by ofa deployment tool)
         app_uuid = os.getenv('APP_UUID', 'DEV-UUID')
         super().__init__(asset_uuid=app_uuid, ksqlClient=ksqlClient,
-                         bootstrap_servers=bootstrap_servers, asset_router_url=asset_router_url)
+                         bootstrap_servers=bootstrap_servers, asset_router_url=asset_router_url,
+                         test_mode=test_mode)
 
         # setup logging
         self.logger = configure_prefixed_logger(
@@ -206,7 +209,8 @@ class OpenFactoryApp(Asset, metaclass=OpenFactoryAppMeta):
                     )
                 )
 
-                self.subscribe_to_attribute(cmd_attribute, make_callback(method))
+                if not self._test_mode:
+                    self.subscribe_to_attribute(cmd_attribute, make_callback(method))
 
     def _register_ofa_method(self, method) -> None:
         """

--- a/openfactory/assets/asset_base.py
+++ b/openfactory/assets/asset_base.py
@@ -52,7 +52,13 @@ class BaseAsset:
     ASSET_ID = None
     ASSET_CONSUMER_CLASS = None
 
-    def __init__(self, ksqlClient: KSQLDBClient, bootstrap_servers: str | None = None, asset_router_url: str | None = None) -> None:
+    def __init__(
+            self,
+            ksqlClient: KSQLDBClient,
+            bootstrap_servers: str | None = None,
+            asset_router_url: str | None = None,
+            test_mode: bool = False
+            ) -> None:
         """
         Initializes the Asset with metadata.
 
@@ -60,6 +66,7 @@ class BaseAsset:
             ksqlClient (KSQLDBClient): Client for interacting with ksqlDB.
             bootstrap_servers (str | None): Kafka bootstrap server address.
             asset_router_url (str | None): Asset Router URL from the OpenFactory Fan-Out-Layer.
+            test_mode (bool): If True, disables live Kafka/ksql interaction (useful for unit tests).
 
         Raises:
             ValueError: If any of the class-level attributes
@@ -77,6 +84,19 @@ class BaseAsset:
           - If ``asset_router_url`` is not explicitly provided, the constructor will attempt to read it from the ``ASSET_ROUTER_URL`` environment variable.
           - When used in an :class:`OpenFactoryApp <openfactory.apps.ofaapp.OpenFactoryApp>` deployed on the OpenFactory cluster, the environment variables ``KAFKA_BROKER`` and ``ASSET_ROUTER_URL`` will be set.
         """
+        super().__setattr__("_test_mode", test_mode)
+
+        # If in test mode, skip all runtime checks and producer setup
+        if test_mode:
+            super().__setattr__("_mocked_attributes", [])
+            super().__setattr__("ksql", ksqlClient)
+            super().__setattr__("loop_thread", None)
+            super().__setattr__("subscribers", {})
+            super().__setattr__("bootstrap_servers", bootstrap_servers)
+            super().__setattr__("asset_router_url", asset_router_url)
+            super().__setattr__("producer", None)
+            return
+
         if not hasattr(self, 'KSQL_ASSET_TABLE') or self.KSQL_ASSET_TABLE is None:
             raise ValueError("KSQL_ASSET_TABLE must be set before initializing the Asset.")
         if not hasattr(self, 'KSQL_ASSET_ID') or self.KSQL_ASSET_ID is None:
@@ -154,6 +174,22 @@ class BaseAsset:
         # Stop the AsyncLoopThread
         self.loop_thread.stop()
 
+    def _get_mocked_attribute_by_id(self, target_id: str) -> AssetAttribute | None:
+        """
+        Retrieve a mocked AssetAttribute by its ID.
+
+        Args:
+            target_id (str): The ID of the AssetAttribute to retrieve.
+
+        Returns:
+            AssetAttribute | None: The matching AssetAttribute if found,
+            otherwise None.
+        """
+        return next(
+            (attr for attr in self._mocked_attributes if attr.id == target_id),
+            None
+        )
+
     @property
     def asset_uuid(self) -> str:
         """
@@ -198,6 +234,11 @@ class BaseAsset:
         Returns:
             List[str]: A list of attribute IDs.
         """
+        # return internal mock list in test_mode
+        if getattr(self, "_test_mode", False):
+            return [attr.id for attr in self._mocked_attributes]
+
+        # in production query ksqlDB
         query = f"SELECT ID FROM {self.KSQL_ASSET_TABLE} WHERE {self.KSQL_ASSET_ID}='{self.ASSET_ID}' AND TYPE != 'Method';"
         result = self.ksql.query(query)
         return [row['ID'] for row in result]
@@ -212,6 +253,17 @@ class BaseAsset:
         Returns:
             List[Dict]: A list of dictionaries containing 'ID', 'VALUE', and cleaned 'TAG'.
         """
+        if getattr(self, "_test_mode", False):
+            return [
+                {
+                    "ID": attr.id,
+                    "VALUE": attr.value,
+                    "TAG": attr.tag,
+                }
+                for attr in self._mocked_attributes
+                if attr.type == attr_type
+            ]
+
         query = f"SELECT ID, VALUE, TAG, TYPE FROM {self.KSQL_ASSET_TABLE} WHERE {self.KSQL_ASSET_ID}='{self.ASSET_ID}' AND TYPE='{attr_type}';"
         result = self.ksql.query(query)
         return [
@@ -389,6 +441,9 @@ class BaseAsset:
                 - If the attribute is a sample, event, or condition, returns an AssetAttribute.
                 - If the attribute is a method, returns a callable method caller function.
         """
+        if getattr(self, "_test_mode", False):
+            return self._get_mocked_attribute_by_id(attribute_id)
+
         query = f"SELECT VALUE, TYPE, TAG, TIMESTAMP FROM {self.KSQL_ASSET_TABLE} WHERE key='{self.ASSET_ID}|{attribute_id}';"
         result = self.ksql.query(query)
 
@@ -479,8 +534,15 @@ class BaseAsset:
             self.producer.send_asset_attribute(self.asset_uuid, value)
             return
 
-        # send kafka message
+        # get the current AssetAttribute
         attr = self.__getattr__(name)
+
+        if getattr(self, "_test_mode", False):
+            # update its value
+            attr.value = value
+            return
+
+        # send kafka message
         self.producer.send_asset_attribute(
             self.asset_uuid,
             AssetAttribute(
@@ -497,6 +559,10 @@ class BaseAsset:
         Args:
             asset_attribute (AssetAttribute): The attribute to be added.
         """
+        if getattr(self, "_test_mode", False):
+            # add to internal mock list
+            self._mocked_attributes.append(asset_attribute)
+            return
         self.producer.send_asset_attribute(self.asset_uuid, asset_attribute)
 
     def _get_reference_list(self, direction: str, as_assets: bool = False) -> List[str | Self]:

--- a/openfactory/assets/asset_class.py
+++ b/openfactory/assets/asset_class.py
@@ -82,7 +82,8 @@ class Asset(BaseAsset):
     def __init__(self, asset_uuid: str,
                  ksqlClient: KSQLDBClient,
                  bootstrap_servers: str | None = None,
-                 asset_router_url: str | None = None) -> None:
+                 asset_router_url: str | None = None,
+                 test_mode: bool = False) -> None:
         """
         Initializes the Asset with metadata and a Kafka producer.
 
@@ -91,6 +92,7 @@ class Asset(BaseAsset):
             ksqlClient (KSQLDBClient): Client for interacting with ksqlDB.
             bootstrap_servers (str | None): Kafka bootstrap server address.
             asset_router_url (str | None): Asset Router URL from the OpenFactory Fan-Out-Layer.
+            test_mode (bool): If True, disables live Kafka/ksql interaction (useful for unit tests).
 
         Raises:
             OFAException: If ``bootstrap_servers`` is not provided and the
@@ -107,7 +109,10 @@ class Asset(BaseAsset):
            The environment variables ``KSQLDB_URL``, ``KAFKA_BROKER`` and ``ASSET_ROUTER_URL`` will be set when deployed on the OpenFactory Cluster.
         """
         object.__setattr__(self, 'ASSET_ID', asset_uuid)
-        super().__init__(ksqlClient, bootstrap_servers, asset_router_url)
+        super().__init__(ksqlClient=ksqlClient,
+                         bootstrap_servers=bootstrap_servers,
+                         asset_router_url=asset_router_url,
+                         test_mode=test_mode)
 
     @property
     def asset_uuid(self) -> str:

--- a/openfactory/assets/asset_uns_class.py
+++ b/openfactory/assets/asset_uns_class.py
@@ -87,7 +87,8 @@ class AssetUNS(BaseAsset):
     def __init__(self, uns_id: str,
                  ksqlClient: KSQLDBClient,
                  bootstrap_servers: str | None = None,
-                 asset_router_url: str | None = None) -> None:
+                 asset_router_url: str | None = None,
+                 test_mode: bool = False) -> None:
         """
         Initializes the Asset with metadata and a Kafka producer.
 
@@ -96,6 +97,7 @@ class AssetUNS(BaseAsset):
             ksqlClient (KSQLDBClient): Client for interacting with ksqlDB.
             bootstrap_servers (str): Kafka bootstrap server address.
             asset_router_url (str | None): Asset Router URL from the OpenFactory Fan-Out-Layer.
+            test_mode (bool): If True, disables live Kafka/ksql interaction (useful for unit tests).
 
         Raises:
             OFAException: If ``bootstrap_servers`` is not provided and the
@@ -109,7 +111,10 @@ class AssetUNS(BaseAsset):
           - When used in an :class:`OpenFactoryApp <openfactory.apps.ofaapp.OpenFactoryApp>` deployed on the OpenFactory cluster, the environment variables ``KAFKA_BROKER`` and ``ASSET_ROUTER_URL`` will be set.
         """
         object.__setattr__(self, 'ASSET_ID', uns_id)
-        super().__init__(ksqlClient, bootstrap_servers, asset_router_url)
+        super().__init__(ksqlClient=ksqlClient,
+                         bootstrap_servers=bootstrap_servers,
+                         asset_router_url=asset_router_url,
+                         test_mode=test_mode)
 
     @property
     def asset_uuid(self) -> str:

--- a/tests/openfactory/apps/test_openfactoryapp_test_mode.py
+++ b/tests/openfactory/apps/test_openfactoryapp_test_mode.py
@@ -1,0 +1,126 @@
+from unittest import TestCase
+from unittest.mock import Mock
+from openfactory.kafka import KSQLDBClient
+from openfactory.assets import AssetAttribute
+from openfactory.apps import OpenFactoryApp, EventAttribute, SampleAttribute, ofa_method
+
+
+class TestApp(OpenFactoryApp):
+
+    status = EventAttribute(value="idle", tag="App.Status")
+    sample_rate = SampleAttribute(value=42, tag="Sample.Rate")
+
+    @ofa_method()
+    def stop_axis(self):
+        """ Stops all motion immediately. """
+        self.logger.info("Stopping all axis")
+
+
+class TestOpenFactoryAppTestMode(TestCase):
+    """
+    Test class OpenFactoryApp in test_mode
+    """
+
+    def setUp(self):
+        self.ksql_mock = Mock(spec=KSQLDBClient)
+
+        self.app = TestApp(
+            asset_router_url='mocked_asset_url',
+            bootstrap_servers='mocked_broker',
+            ksqlClient=self.ksql_mock,
+            test_mode=True
+        )
+
+    def test_regular_attributes(self):
+        """ Test regular python attributes """
+        # Set arbitrary attributes
+        self.app.foo = 123
+        self.app.bar = "hello"
+
+        self.assertEqual(self.app.foo, 123)
+        self.assertEqual(self.app.bar, "hello")
+
+    def test_declarative_attributes(self):
+        """ Test declarative attributes """
+        self.assertEqual(self.app.sample_rate.value, 42)
+        self.assertEqual(self.app.sample_rate.type, 'Samples')
+        self.assertEqual(self.app.sample_rate.tag, 'Sample.Rate')
+        self.assertEqual(self.app.status.value, "idle")
+        self.assertEqual(self.app.status.type, 'Events')
+        self.assertEqual(self.app.status.tag, 'App.Status')
+
+    def test_ofa_methods_attributes(self):
+        """ Test ofa_methods command attributes """
+        self.assertEqual(self.app.stop_axis_CMD.value, '')
+        self.assertEqual(self.app.stop_axis_CMD.type, 'OpenFactory')
+        self.assertEqual(self.app.stop_axis_CMD.tag, 'Method.Command')
+
+    def test_add_attribute(self):
+        """ Test that add_attributes populates internal list in test_mode """
+        # Add two AssetAttributes
+        attribute1 = AssetAttribute(id='test_attribute1', value='attr1', type='Events', tag='test')
+        attribute2 = AssetAttribute(id='test_attribute2', value='attr1', type='Events', tag='test')
+        self.app.add_attribute(attribute1)
+        self.app.add_attribute(attribute2)
+
+        self.assertIn(attribute1, self.app._mocked_attributes)
+        self.assertIn(attribute2, self.app._mocked_attributes)
+
+    def test_attributes(self):
+        """ Test attributes() """
+        # Add two AssetAttributes
+        attribute1 = AssetAttribute(id='attribute1', value='attr1', type='Events', tag='test')
+        attribute2 = AssetAttribute(id='attribute2', value=5, type='Samples', tag='test')
+        self.app.add_attribute(attribute1)
+        self.app.add_attribute(attribute2)
+
+        self.assertIn('attribute1', self.app.attributes())
+        self.assertIn('attribute2', self.app.attributes())
+
+    def test_get_attributes_by_type(self):
+        """ Test _get_attributes_by_type """
+        # Add two AssetAttributes
+        attribute1 = AssetAttribute(id='attribute1', value='attr1', type='Events', tag='test')
+        attribute2 = AssetAttribute(id='attribute2', value=5, type='Samples', tag='test')
+        self.app.add_attribute(attribute1)
+        self.app.add_attribute(attribute2)
+
+        self.assertIn({'ID': 'attribute1', 'VALUE': 'attr1', 'TAG': 'test'}, self.app._get_attributes_by_type('Events'))
+        self.assertIn({'ID': 'attribute2', 'VALUE': 5, 'TAG': 'test'}, self.app._get_attributes_by_type('Samples'))
+
+    def test_samples(self):
+        """ Test samples() """
+        # Add two AssetAttributes
+        attr = AssetAttribute(id='attribute', value=5, type='Samples', tag='test')
+        self.app.add_attribute(attr)
+
+        self.assertIn({'ID': 'attribute', 'VALUE': 5, 'TAG': 'test'}, self.app.samples())
+
+    def test_events(self):
+        """ Test events() """
+        # Add two AssetAttributes
+        attr = AssetAttribute(id='attribute', value='some_value', type='Events', tag='test')
+        self.app.add_attribute(attr)
+
+        self.assertIn({'ID': 'attribute', 'VALUE': 'some_value', 'TAG': 'test'}, self.app.events())
+
+    def test_get_mocked_attribute_by_id(self):
+        """ Test __get_mocked_attribute_by_id """
+        # Add an AssetAttribute
+        attr = AssetAttribute(id='attribute1', value='attr1', type='Events', tag='test')
+        self.app.add_attribute(attr)
+        self.assertEqual(self.app._get_mocked_attribute_by_id('attribute1'), attr)
+
+        # A none existing AssetAttribute should return None
+        self.assertEqual(self.app._get_mocked_attribute_by_id('does_not_exist'), None)
+
+    def test_setattr_in_test_mode_bypasses_producer(self):
+        """ Test AssetAttribute attributes """
+        # Add an AssetAttribute
+        attribute1 = AssetAttribute(id='attribute1', value='attr1', type='Events', tag='test')
+        self.app.add_attribute(attribute1)
+        self.assertEqual(self.app.attribute1.value, "attr1")
+
+        # Set new value
+        self.app.attribute1 = "hello"
+        self.assertEqual(self.app.attribute1.value, "hello")

--- a/tests/openfactory/assets/test_asset_test_mode.py
+++ b/tests/openfactory/assets/test_asset_test_mode.py
@@ -1,0 +1,99 @@
+from unittest import TestCase
+from unittest.mock import Mock
+from openfactory.kafka import KSQLDBClient
+from openfactory.assets import AssetAttribute
+from openfactory.assets.asset_class import Asset
+
+
+class TestAssetTestMode(TestCase):
+    """
+    Test class Asset in test_mode
+    """
+
+    def setUp(self):
+        self.ksql_mock = Mock(spec=KSQLDBClient)
+
+        self.asset = Asset(
+            'test_001',
+            ksqlClient=self.ksql_mock,
+            bootstrap_servers='mocked_broker',
+            asset_router_url='mocked_asset_url',
+            test_mode=True
+        )
+
+    def test_regular_attributes(self):
+        """ Test regular python attributes """
+        # Set arbitrary attributes
+        self.asset.foo = 123
+        self.asset.bar = "hello"
+
+        self.assertEqual(self.asset.foo, 123)
+        self.assertEqual(self.asset.bar, "hello")
+
+    def test_add_attribute(self):
+        """ Test that add_attributes populates internal list in test_mode """
+        # Add two AssetAttributes
+        attribute1 = AssetAttribute(id='test_attribute1', value='attr1', type='Events', tag='test')
+        attribute2 = AssetAttribute(id='test_attribute2', value='attr1', type='Events', tag='test')
+        self.asset.add_attribute(attribute1)
+        self.asset.add_attribute(attribute2)
+
+        self.assertEqual(self.asset._mocked_attributes, [attribute1, attribute2])
+
+    def test_attributes(self):
+        """ Test attributes() """
+        # Add two AssetAttributes
+        attribute1 = AssetAttribute(id='attribute1', value='attr1', type='Events', tag='test')
+        attribute2 = AssetAttribute(id='attribute2', value=5, type='Samples', tag='test')
+        self.asset.add_attribute(attribute1)
+        self.asset.add_attribute(attribute2)
+
+        self.assertEqual(self.asset.attributes(), ['attribute1', 'attribute2'])
+
+    def test_get_attributes_by_type(self):
+        """ Test _get_attributes_by_type """
+        # Add two AssetAttributes
+        attribute1 = AssetAttribute(id='attribute1', value='attr1', type='Events', tag='test')
+        attribute2 = AssetAttribute(id='attribute2', value=5, type='Samples', tag='test')
+        self.asset.add_attribute(attribute1)
+        self.asset.add_attribute(attribute2)
+
+        self.assertEqual(self.asset._get_attributes_by_type('Events'), [{'ID': 'attribute1', 'VALUE': 'attr1', 'TAG': 'test'}])
+        self.assertEqual(self.asset._get_attributes_by_type('Samples'), [{'ID': 'attribute2', 'VALUE': 5, 'TAG': 'test'}])
+
+    def test_samples(self):
+        """ Test samples() """
+        # Add two AssetAttributes
+        attr = AssetAttribute(id='attribute', value=5, type='Samples', tag='test')
+        self.asset.add_attribute(attr)
+
+        self.assertEqual(self.asset.samples(), [{'ID': 'attribute', 'VALUE': 5, 'TAG': 'test'}])
+
+    def test_events(self):
+        """ Test events() """
+        # Add two AssetAttributes
+        attr = AssetAttribute(id='attribute', value='some_value', type='Events', tag='test')
+        self.asset.add_attribute(attr)
+
+        self.assertEqual(self.asset.events(), [{'ID': 'attribute', 'VALUE': 'some_value', 'TAG': 'test'}])
+
+    def test_get_mocked_attribute_by_id(self):
+        """ Test __get_mocked_attribute_by_id """
+        # Add an AssetAttribute
+        attr = AssetAttribute(id='attribute1', value='attr1', type='Events', tag='test')
+        self.asset.add_attribute(attr)
+        self.assertEqual(self.asset._get_mocked_attribute_by_id('attribute1'), attr)
+
+        # A none existing AssetAttribute should return None
+        self.assertEqual(self.asset._get_mocked_attribute_by_id('does_not_exist'), None)
+
+    def test_setattr_in_test_mode_bypasses_producer(self):
+        """ Test AssetAttribute attributes """
+        # Add an AssetAttribute
+        attribute1 = AssetAttribute(id='attribute1', value='attr1', type='Events', tag='test')
+        self.asset.add_attribute(attribute1)
+        self.assertEqual(self.asset.attribute1.value, "attr1")
+
+        # Set new value
+        self.asset.attribute1 = "hello"
+        self.assertEqual(self.asset.attribute1.value, "hello")

--- a/tests/openfactory/assets/test_asset_uns_test_mode.py
+++ b/tests/openfactory/assets/test_asset_uns_test_mode.py
@@ -1,0 +1,99 @@
+from unittest import TestCase
+from unittest.mock import Mock
+from openfactory.kafka import KSQLDBClient
+from openfactory.assets import AssetAttribute
+from openfactory.assets.asset_uns_class import AssetUNS
+
+
+class TestAssetUNSTestMode(TestCase):
+    """
+    Test class AssetUNS in test_mode
+    """
+
+    def setUp(self):
+        self.ksql_mock = Mock(spec=KSQLDBClient)
+
+        self.asset = AssetUNS(
+            'test_001',
+            ksqlClient=self.ksql_mock,
+            bootstrap_servers='mocked_broker',
+            asset_router_url='mocked_asset_url',
+            test_mode=True
+        )
+
+    def test_regular_attributes(self):
+        """ Test regular python attributes """
+        # Set arbitrary attributes
+        self.asset.foo = 123
+        self.asset.bar = "hello"
+
+        self.assertEqual(self.asset.foo, 123)
+        self.assertEqual(self.asset.bar, "hello")
+
+    def test_add_attribute(self):
+        """ Test that add_attributes populates internal list in test_mode """
+        # Add two AssetAttributes
+        attribute1 = AssetAttribute(id='test_attribute1', value='attr1', type='Events', tag='test')
+        attribute2 = AssetAttribute(id='test_attribute2', value='attr1', type='Events', tag='test')
+        self.asset.add_attribute(attribute1)
+        self.asset.add_attribute(attribute2)
+
+        self.assertEqual(self.asset._mocked_attributes, [attribute1, attribute2])
+
+    def test_attributes(self):
+        """ Test attributes() """
+        # Add two AssetAttributes
+        attribute1 = AssetAttribute(id='attribute1', value='attr1', type='Events', tag='test')
+        attribute2 = AssetAttribute(id='attribute2', value=5, type='Samples', tag='test')
+        self.asset.add_attribute(attribute1)
+        self.asset.add_attribute(attribute2)
+
+        self.assertEqual(self.asset.attributes(), ['attribute1', 'attribute2'])
+
+    def test_get_attributes_by_type(self):
+        """ Test _get_attributes_by_type """
+        # Add two AssetAttributes
+        attribute1 = AssetAttribute(id='attribute1', value='attr1', type='Events', tag='test')
+        attribute2 = AssetAttribute(id='attribute2', value=5, type='Samples', tag='test')
+        self.asset.add_attribute(attribute1)
+        self.asset.add_attribute(attribute2)
+
+        self.assertEqual(self.asset._get_attributes_by_type('Events'), [{'ID': 'attribute1', 'VALUE': 'attr1', 'TAG': 'test'}])
+        self.assertEqual(self.asset._get_attributes_by_type('Samples'), [{'ID': 'attribute2', 'VALUE': 5, 'TAG': 'test'}])
+
+    def test_samples(self):
+        """ Test samples() """
+        # Add two AssetAttributes
+        attr = AssetAttribute(id='attribute', value=5, type='Samples', tag='test')
+        self.asset.add_attribute(attr)
+
+        self.assertEqual(self.asset.samples(), [{'ID': 'attribute', 'VALUE': 5, 'TAG': 'test'}])
+
+    def test_events(self):
+        """ Test events() """
+        # Add two AssetAttributes
+        attr = AssetAttribute(id='attribute', value='some_value', type='Events', tag='test')
+        self.asset.add_attribute(attr)
+
+        self.assertEqual(self.asset.events(), [{'ID': 'attribute', 'VALUE': 'some_value', 'TAG': 'test'}])
+
+    def test_get_mocked_attribute_by_id(self):
+        """ Test __get_mocked_attribute_by_id """
+        # Add an AssetAttribute
+        attr = AssetAttribute(id='attribute1', value='attr1', type='Events', tag='test')
+        self.asset.add_attribute(attr)
+        self.assertEqual(self.asset._get_mocked_attribute_by_id('attribute1'), attr)
+
+        # A none existing AssetAttribute should return None
+        self.assertEqual(self.asset._get_mocked_attribute_by_id('does_not_exist'), None)
+
+    def test_setattr_in_test_mode_bypasses_producer(self):
+        """ Test AssetAttribute attributes """
+        # Add an AssetAttribute
+        attribute1 = AssetAttribute(id='attribute1', value='attr1', type='Events', tag='test')
+        self.asset.add_attribute(attribute1)
+        self.assertEqual(self.asset.attribute1.value, "attr1")
+
+        # Set new value
+        self.asset.attribute1 = "hello"
+        self.assertEqual(self.asset.attribute1.value, "hello")

--- a/tests/openfactory/assets/test_baseasset_test_mode.py
+++ b/tests/openfactory/assets/test_baseasset_test_mode.py
@@ -1,0 +1,123 @@
+from unittest import TestCase
+from unittest.mock import Mock
+from openfactory.kafka import KSQLDBClient
+from openfactory.assets import AssetAttribute
+from openfactory.assets.asset_base import BaseAsset, KafkaAssetConsumer
+
+
+class ValidAsset(BaseAsset):
+    """ A valid Asset in test_mode """
+
+    KSQL_ASSET_TABLE = "assets"
+    KSQL_ASSET_ID = "asset_uuid"
+    ASSET_CONSUMER_CLASS = KafkaAssetConsumer
+
+    def __init__(self, asset_id, ksqlClient, test_mode):
+        object.__setattr__(self, 'ASSET_ID', asset_id)
+        super().__init__(ksqlClient, test_mode=test_mode)
+
+    @property
+    def asset_uuid(self):
+        return self.ASSET_ID
+
+
+class TestBaseAssetTestMode(TestCase):
+    """
+    Test class BaseAsset in test_mode
+    """
+
+    def setUp(self):
+        self.ksql_mock = Mock(spec=KSQLDBClient)
+
+    def test_regular_attributes(self):
+        """ Test regular python attributes """
+        asset = ValidAsset("uuid-test", self.ksql_mock, test_mode=True)
+
+        # Set arbitrary attributes
+        asset.foo = 123
+        asset.bar = "hello"
+
+        self.assertEqual(asset.foo, 123)
+        self.assertEqual(asset.bar, "hello")
+
+    def test_add_attribute(self):
+        """ Test that add_attributes populates internal list in test_mode """
+        asset = ValidAsset("uuid-test", self.ksql_mock, test_mode=True)
+
+        # Add two AssetAttributes
+        attribute1 = AssetAttribute(id='test_attribute1', value='attr1', type='Events', tag='test')
+        attribute2 = AssetAttribute(id='test_attribute2', value='attr1', type='Events', tag='test')
+        asset.add_attribute(attribute1)
+        asset.add_attribute(attribute2)
+
+        self.assertEqual(asset._mocked_attributes, [attribute1, attribute2])
+
+    def test_attributes(self):
+        """ Test attributes() """
+        asset = ValidAsset("uuid-test", self.ksql_mock, test_mode=True)
+
+        # Add two AssetAttributes
+        attribute1 = AssetAttribute(id='attribute1', value='attr1', type='Events', tag='test')
+        attribute2 = AssetAttribute(id='attribute2', value=5, type='Samples', tag='test')
+        asset.add_attribute(attribute1)
+        asset.add_attribute(attribute2)
+
+        self.assertEqual(asset.attributes(), ['attribute1', 'attribute2'])
+
+    def test_get_attributes_by_type(self):
+        """ Test _get_attributes_by_type """
+        asset = ValidAsset("uuid-test", self.ksql_mock, test_mode=True)
+
+        # Add two AssetAttributes
+        attribute1 = AssetAttribute(id='attribute1', value='attr1', type='Events', tag='test')
+        attribute2 = AssetAttribute(id='attribute2', value=5, type='Samples', tag='test')
+        asset.add_attribute(attribute1)
+        asset.add_attribute(attribute2)
+
+        self.assertEqual(asset._get_attributes_by_type('Events'), [{'ID': 'attribute1', 'VALUE': 'attr1', 'TAG': 'test'}])
+        self.assertEqual(asset._get_attributes_by_type('Samples'), [{'ID': 'attribute2', 'VALUE': 5, 'TAG': 'test'}])
+
+    def test_samples(self):
+        """ Test samples() """
+        asset = ValidAsset("uuid-test", self.ksql_mock, test_mode=True)
+
+        # Add two AssetAttributes
+        attr = AssetAttribute(id='attribute', value=5, type='Samples', tag='test')
+        asset.add_attribute(attr)
+
+        self.assertEqual(asset.samples(), [{'ID': 'attribute', 'VALUE': 5, 'TAG': 'test'}])
+
+    def test_events(self):
+        """ Test events() """
+        asset = ValidAsset("uuid-test", self.ksql_mock, test_mode=True)
+
+        # Add two AssetAttributes
+        attr = AssetAttribute(id='attribute', value='some_value', type='Events', tag='test')
+        asset.add_attribute(attr)
+
+        self.assertEqual(asset.events(), [{'ID': 'attribute', 'VALUE': 'some_value', 'TAG': 'test'}])
+
+    def test_get_mocked_attribute_by_id(self):
+        """ Test __get_mocked_attribute_by_id """
+        asset = ValidAsset("uuid-test", self.ksql_mock, test_mode=True)
+
+        # Add an AssetAttribute
+        attr = AssetAttribute(id='attribute1', value='attr1', type='Events', tag='test')
+        asset.add_attribute(attr)
+        self.assertEqual(asset._get_mocked_attribute_by_id('attribute1'), attr)
+
+        # A none existing AssetAttribute should return None
+        self.assertEqual(asset._get_mocked_attribute_by_id('does_not_exist'), None)
+
+    def test_setattr_in_test_mode_bypasses_producer(self):
+        """ Test AssetAttribute attributes """
+        asset = ValidAsset("uuid-test", self.ksql_mock, test_mode=True)
+
+        # Add an AssetAttribute
+        attribute1 = AssetAttribute(id='attribute1', value='attr1', type='Events', tag='test')
+        asset.add_attribute(attribute1)
+        self.assertEqual(asset.attribute1.value, "attr1")
+
+        # Set new value
+        asset.attribute1 = "hello"
+        self.assertEqual(asset.attribute1.value, "hello")


### PR DESCRIPTION
Add a `test_mode` flag to the classes, `BaseAsset`, `Asset`, `AssetUNS` and `OpenFactoryApp` to ease the writing of unit tests.