### PR TITLE
206 add openfactoryfastapiapp for integrating fastapi into openfactory applications

### DIFF
--- a/docs/api/apps/index.rst
+++ b/docs/api/apps/index.rst
@@ -160,3 +160,4 @@ See Also
    ofa_app
    ofa_attributes
    ofa_method
+   ofa_fastapi_app

--- a/docs/api/apps/ofa_fastapi_app.rst
+++ b/docs/api/apps/ofa_fastapi_app.rst
@@ -1,0 +1,4 @@
+OpenFactoryFastAPIApp
+=====================
+
+.. autoclass:: openfactory.apps.ofa_fastapi_app.OpenFactoryFastAPIApp

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -27,6 +27,7 @@ intersphinx_mapping = {
     'pandas': ('https://pandas.pydata.org/pandas-docs/stable/', None),
     'fsspec': ('https://filesystem-spec.readthedocs.io/en/latest/', None),
     'requests': ('https://requests.readthedocs.io/en/latest/', None),
+    "fastapi": ("https://fastapi.tiangolo.com/", None),
 }
 
 nitpick_ignore = [

--- a/openfactory/apps/__init__.py
+++ b/openfactory/apps/__init__.py
@@ -1,5 +1,6 @@
 """ OpenFactory apps module. """
 
 from openfactory.apps.ofaapp import OpenFactoryApp
+from openfactory.apps.ofa_fastapi_app import OpenFactoryFastAPIApp
 from openfactory.apps.decorators import ofa_method
 from openfactory.apps.attributefield import AttributeField, EventAttribute, SampleAttribute

--- a/openfactory/apps/ofa_fastapi_app.py
+++ b/openfactory/apps/ofa_fastapi_app.py
@@ -1,0 +1,359 @@
+import asyncio
+import os
+import uvicorn
+import logging
+from fastapi import FastAPI
+from openfactory.kafka import KSQLDBClient
+from openfactory.apps import OpenFactoryApp
+
+
+class OpenFactoryFastAPIApp(OpenFactoryApp):
+    """
+    OpenFactory application with an embedded FastAPI web interface.
+
+    Extends :class:`OpenFactoryApp <openfactory.apps.ofaapp.OpenFactoryApp>` by attaching a
+    :class:`fastapi.FastAPI` application to the OpenFactory runtime.
+    This allows exposing HTTP endpoints alongside the standard OpenFactory
+    asset, attribute, and method mechanisms.
+
+    The FastAPI application is available via the :attr:`api` attribute and
+    can be used exactly as in a standard FastAPI project.
+
+    Runtime behavior:
+        - Calling :meth:`run` starts both the OpenFactory application and an embedded HTTP server.
+        - The HTTP server is powered by Uvicorn and serves the attached :class:`fastapi.FastAPI` application.
+        - The server listens on all network interfaces (``0.0.0.0``).
+        - The listening port is defined by the ``PORT`` environment variable, or defaults to ``4000`` if unset.
+        - The server log level is aligned with the OpenFactory application logger.
+
+    Attributes:
+        api (fastapi.FastAPI): FastAPI application instance attached to the OpenFactory app.
+
+    .. admonition:: Usage Example (inline routes)
+
+        .. code-block:: python
+
+            import os
+            from openfactory.apps import OpenFactoryFastAPIApp, EventAttribute, ofa_method
+            from openfactory.kafka import KSQLDBClient
+
+            class DemoFastAPIApp(OpenFactoryFastAPIApp):
+
+                status = EventAttribute(value="idle", tag="App.Status")
+
+                def __init__(self, *args, **kwargs):
+                    super().__init__(*args, **kwargs)
+
+                    @self.api.get("/")
+                    async def root():
+                        return {"status": self.status.value}
+
+                @ofa_method(description="Move axis")
+                def move_axis(self, x: float, y: float):
+                    self.logger.info(f"Move to {x},{y}")
+
+            app = DemoFastAPIApp(
+                ksqlClient=KSQLDBClient(os.getenv("KSQLDB_URL", "http://localhost:8088")),
+                bootstrap_servers=os.getenv("KAFKA_BROKER", "localhost:9092"),
+            )
+            app.run()
+
+    For larger applications, routes can be split into modules and included using routers:
+
+    .. admonition:: Using routers (recommended for larger applications)
+
+        .. code-block:: python
+
+            # main.py
+            import os
+            from openfactory.apps import OpenFactoryFastAPIApp, EventAttribute, ofa_method
+            from openfactory.kafka import KSQLDBClient
+            from routes import root, move
+
+            class DemoFastAPIApp(OpenFactoryFastAPIApp):
+
+                status = EventAttribute(value="idle", tag="App.Status")
+
+                def __init__(self, *args, **kwargs):
+                    super().__init__(*args, **kwargs)
+
+                    # expose OpenFactory App inside FastAPI
+                    self.api.state.ofa_app = self
+
+                    # include routers
+                    self.api.include_router(root.router)
+                    self.api.include_router(move.router)
+
+                @ofa_method(description="Move axis")
+                def move_axis(self, x: float, y: float):
+                    self.logger.info(f"Move to {x},{y}")
+
+            app = DemoFastAPIApp(
+                ksqlClient=KSQLDBClient(os.getenv("KSQLDB_URL", "http://localhost:8088")),
+                bootstrap_servers=os.getenv("KAFKA_BROKER", "localhost:9092"),
+            )
+            app.run()
+
+        .. code-block:: python
+
+            # routes/root.py
+            from fastapi import APIRouter, Request
+
+            router = APIRouter()
+
+            @router.get("/")
+            async def root(request: Request):
+                ofa_app = request.app.state.ofa_app
+                return {"status": ofa_app.status.value}
+
+        .. code-block:: python
+
+            # routes/move.py
+            from fastapi import APIRouter, Request
+
+            router = APIRouter()
+
+            @router.post("/move")
+            async def move(x: float, y: float, request: Request):
+                ofa_app = request.app.state.ofa_app
+                ofa_app.move_axis(x, y)
+                return {"message": "moving"}
+
+    Note:
+      - The FastAPI application is accessible via :attr:`api` and behaves like a standard FastAPI instance.
+      - Route definitions can be added either directly using :attr:`api` or via :class:`api.include_router() <fastapi.FastAPI>`.
+      - For small applications, routes can be defined inline; for larger applications, using routers is recommended.
+      - Only asynchronous execution is supported. Subclasses may optionally implement :meth:`async_main_loop` for background tasks.
+      - The synchronous :meth:`OpenFactoryApp.main_loop() <openfactory.apps.ofaapp.OpenFactoryApp.main_loop>` is not supported in this class.
+      - OpenFactory features such as attributes, methods, and asset communication remain unchanged.
+      - When deployed on the OpenFactory platform, the ``PORT`` environment variable is set automatically by the deployment tool.
+
+    .. seealso::
+        - :class:`openfactory.apps.ofaapp.OpenFactoryApp`
+        - :class:`fastapi.FastAPI`
+        - `FastAPI documentation <https://fastapi.tiangolo.com/>`_
+    """
+
+    def __init__(
+        self,
+        ksqlClient: KSQLDBClient,
+        bootstrap_servers: str | None = None,
+        asset_router_url: str | None = None,
+        loglevel: str = "INFO",
+        test_mode: bool = False,
+    ) -> None:
+        """
+        Initialize the OpenFactory FastAPI application.
+
+        This constructor forwards all parameters to
+        :class:`OpenFactoryApp <openfactory.apps.ofaapp.OpenFactoryApp>`
+        and additionally creates a :class:`fastapi.FastAPI` instance
+        accessible via :attr:`api`.
+
+        Args:
+            ksqlClient: KSQL client instance.
+            bootstrap_servers: Kafka bootstrap server address.
+            asset_router_url: Asset Router URL.
+            loglevel: Logging level (e.g., ``INFO``, ``DEBUG``).
+            test_mode: Enables test mode (disables live Kafka/ksql interaction).
+
+        See also:
+            :class:`OpenFactoryApp <openfactory.apps.ofaapp.OpenFactoryApp>`
+            for full initialization details and environment variable handling.
+        """
+        super().__init__(ksqlClient=ksqlClient, bootstrap_servers=bootstrap_servers,
+                         asset_router_url=asset_router_url,
+                         loglevel=loglevel,
+                         test_mode=test_mode)
+
+        self._shutdown_event = asyncio.Event()
+        self.api = FastAPI()
+        self.configure_routes()
+
+    def configure_routes(self) -> None:
+        """
+        Configure HTTP routes for the FastAPI application.
+
+        This method can be overridden by subclasses to define routes directly
+        using :attr:`api`.
+
+        .. admonition:: Example
+
+            .. code-block:: python
+
+                def configure_routes(self):
+
+                    @self.api.get("/")
+                    async def root():
+                        return {"status": "ok"}
+
+        Note:
+            For larger applications, prefer using :class:`api.include_router() <fastapi.FastAPI>` instead
+            of overriding this method.
+        """
+        pass
+
+    async def _run_fastapi(self) -> None:
+        """
+        Run the FastAPI application using Uvicorn.
+
+        This starts an ASGI server and serves HTTP requests until the application
+        is stopped.
+
+        The server listens on all network interfaces (``0.0.0.0``) and uses the
+        port defined by the ``PORT`` environment variable, or ``4000`` if the
+        variable is not set.
+
+        Note:
+            - The log level of the server is aligned with the OpenFactory application logger.
+            - This method is intended for internal use and is called by :meth:`async_run`.
+        """
+        log_level = logging.getLevelName(self.logger.level).lower()
+
+        config = uvicorn.Config(
+            self.api,
+            host="0.0.0.0",
+            port=int(os.getenv("PORT", "4000")),
+            log_level=log_level
+        )
+        self._uvicorn_server = uvicorn.Server(config)
+        await self._uvicorn_server.serve()
+
+    def _user_defined_async_main(self) -> bool:
+        """
+        Check whether the subclass defines :meth:`async_main_loop`.
+
+        Returns:
+            bool: ``True`` if the subclass overrides :meth:`async_main_loop`,
+            otherwise ``False``.
+        """
+        return type(self).async_main_loop is not OpenFactoryApp.async_main_loop
+
+    def _user_defined_main(self) -> bool:
+        """
+        Check whether the subclass defines :meth:`main_loop`.
+
+        Returns:
+            bool: ``True`` if the subclass overrides :meth:`OpenFactoryApp.main_loop <openfactory.apps.ofaapp.OpenFactoryApp.main_loop>`,
+            otherwise ``False``.
+        """
+        return type(self).main_loop is not OpenFactoryApp.main_loop
+
+    async def _run_openfactory(self) -> None:
+        """
+        Execute the OpenFactory application logic.
+
+        This method ensures that only asynchronous execution is used.
+        If :meth:`main_loop` is defined, a runtime error is raised.
+
+        Behavior:
+            - If :meth:`async_main_loop` is defined, it is awaited.
+            - Otherwise, the coroutine waits indefinitely.
+
+        Raises:
+            RuntimeError: If a synchronous :meth:`main_loop` is defined.
+        """
+
+        if self._user_defined_main():
+            raise RuntimeError(
+                "OpenFactoryFastAPIApp does NOT support 'main_loop'. "
+                "Use 'async_main_loop' instead."
+            )
+
+        if self._user_defined_async_main():
+            await self.async_main_loop()
+        else:
+            # do nothing
+            await self._shutdown_event.wait()
+
+    async def async_run(self) -> None:
+        """
+        Asynchronous entry point of the application.
+
+        Starts both the FastAPI server and the OpenFactory logic concurrently.
+
+        This method:
+            - Displays the welcome banner
+            - Sets the application availability
+            - Runs FastAPI and OpenFactory tasks concurrently
+
+        Raises:
+            Exception: Any unhandled exception during execution is logged and
+               triggers :meth:`OpenFactoryApp.app_event_loop_stopped() <openfactory.apps.ofaapp.OpenFactoryApp.app_event_loop_stopped>`.
+        """
+
+        self.welcome_banner()
+        self.avail = 'AVAILABLE'
+        self.logger.info("Starting async main loop")
+
+        task_fastapi = asyncio.create_task(self._run_fastapi(), name="FastAPI")
+        task_ofa = asyncio.create_task(self._run_openfactory(), name="OpenFactory")
+
+        tasks = {task_fastapi, task_ofa}
+
+        try:
+            done, pending = await asyncio.wait(
+                tasks,
+                return_when=asyncio.FIRST_EXCEPTION
+            )
+
+            # If any task raised → re-raise it
+            for task in done:
+                if exc := task.exception():
+                    self.logger.error(f"Task {task.get_name()} failed")
+                    raise exc
+
+        except Exception:
+            self.logger.exception("Error in async_run")
+
+        finally:
+            self.logger.info("Shutting down application")
+
+            # Stop uvicorn cleanly
+            server = getattr(self, "_uvicorn_server", None)
+            if server:
+                server.should_exit = True
+
+            # Cancel remaining tasks
+            for task in tasks:
+                if not task.done():
+                    task.cancel()
+
+            # Wait for cancellation to complete
+            await asyncio.gather(*tasks, return_exceptions=True)
+
+            # OpenFactory cleanup
+            try:
+                self.app_event_loop_stopped()
+            except Exception:
+                pass
+
+            self.logger.info("Application shutdown complete")
+
+    def run(self) -> None:
+        """
+        Start the application using a synchronous entry point.
+
+        This method runs :meth:`async_run` inside an asyncio event loop.
+        """
+        asyncio.run(self.async_run())
+
+    async def async_main_loop(self) -> None:
+        """
+        Default asynchronous main loop.
+
+        Keeps the application alive when no custom loop is provided.
+
+        Subclasses can override this method to implement background logic.
+
+        .. admonition:: Example
+
+            .. code-block:: python
+
+                async def async_main_loop(self):
+                    while True:
+                        await asyncio.sleep(5)
+                        self.logger.info("Background task running")
+        """
+        while True:
+            await asyncio.sleep(3600)

--- a/openfactory/openfactory_manager.py
+++ b/openfactory/openfactory_manager.py
@@ -167,6 +167,21 @@ class OpenFactoryManager(OpenFactory):
                f"ASSET_ROUTER_URL={config.ASSET_ROUTER_URL}",
                f"DOCKER_SERVICE={application.uuid.lower()}"]
 
+        # if routing section is defined export PORT variable
+        routing = application.routing
+        if routing:
+            # check conflict
+            if application.environment:
+                for item in application.environment:
+                    var, _ = item.split("=", 1)
+                    if var.strip() == "PORT":
+                        user_notify.fail(
+                            f"Application {application.uuid}: "
+                            "PORT must not be defined in 'environment' when routing is enabled. "
+                            "It is managed automatically by OpenFactory.")
+                        return
+            env.append(f"PORT={routing.port}")
+
         # Add STORAGE only if not None
         if application.storage is not None:
             # Serialize storage config as JSON

--- a/tests/openfactory/apps/test_ofa_fastapi_app_http.py
+++ b/tests/openfactory/apps/test_ofa_fastapi_app_http.py
@@ -1,0 +1,63 @@
+import unittest
+from unittest.mock import patch, MagicMock
+from fastapi.testclient import TestClient
+from openfactory.apps import OpenFactoryFastAPIApp
+
+
+class _HTTPTestApp(OpenFactoryFastAPIApp):
+    """
+    Test OpenFactoryFastAPIApp class with some endpoints
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        # expose OFA app for router-style access if needed
+        self.api.state.ofa_app = self
+
+        @self.api.get("/")
+        async def root():
+            return {"status": "ok"}
+
+        @self.api.post("/move")
+        async def move(x: float, y: float):
+            return {"x": x, "y": y}
+
+
+class TestOpenFactoryFastAPIAppHTTP(unittest.TestCase):
+    """
+    Test if FastAPI app in the OpenFactoryFastAPIApp indeed talks with the endpoints
+    """
+
+    def setUp(self):
+        self.ksql_mock = MagicMock()
+
+        self.asset_producer_patcher = patch("openfactory.assets.asset_base.AssetProducer")
+        self.asset_producer_patcher.start()
+        self.addCleanup(self.asset_producer_patcher.stop)
+
+        self.deregister_patcher = patch("openfactory.apps.ofaapp.deregister_asset")
+        self.deregister_patcher.start()
+        self.addCleanup(self.deregister_patcher.stop)
+
+        self.app = _HTTPTestApp(
+            ksqlClient=self.ksql_mock,
+            bootstrap_servers="mock",
+            asset_router_url="mock"
+        )
+
+        self.client = TestClient(self.app.api)
+
+    def test_get_root(self):
+        response = self.client.get("/")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"status": "ok"})
+
+    def test_post_move(self):
+        response = self.client.post("/move", params={"x": 1.5, "y": 2.5})
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"x": 1.5, "y": 2.5})
+
+    def test_invalid_route(self):
+        response = self.client.get("/unknown")
+        self.assertEqual(response.status_code, 404)

--- a/tests/openfactory/apps/test_openfactory_fastapi_app.py
+++ b/tests/openfactory/apps/test_openfactory_fastapi_app.py
@@ -1,0 +1,247 @@
+import unittest
+from unittest.mock import patch, MagicMock, AsyncMock
+import asyncio
+from fastapi import FastAPI
+from openfactory.apps import OpenFactoryFastAPIApp
+
+
+class _TestApp(OpenFactoryFastAPIApp):
+    async def async_main_loop(self):
+        await asyncio.sleep(0.01)
+
+
+class TestOpenFactoryFastAPIApp(unittest.TestCase):
+    """
+    Tests for class OpenFactoryFastAPIApp
+    """
+
+    def setUp(self):
+        self.ksql_mock = MagicMock()
+
+        self.asset_producer_patcher = patch("openfactory.assets.asset_base.AssetProducer")
+        self.asset_producer_patcher.start()
+        self.addCleanup(self.asset_producer_patcher.stop)
+
+        self.deregister_patcher = patch('openfactory.apps.ofaapp.deregister_asset')
+        self.deregister_patcher.start()
+        self.addCleanup(self.deregister_patcher.stop)
+
+    def test_initialization_creates_fastapi(self):
+        """" Test initialization creates FastAPI app """
+        app = OpenFactoryFastAPIApp(
+            ksqlClient=self.ksql_mock,
+            bootstrap_servers='mock',
+            asset_router_url='mock'
+        )
+
+        self.assertIsInstance(app.api, FastAPI)
+
+    def test_configure_routes_called(self):
+        """ Test initialization calls configure_routes """
+        class App(OpenFactoryFastAPIApp):
+            def configure_routes(self):
+                self.called = True
+
+        app = App(
+            ksqlClient=self.ksql_mock,
+            bootstrap_servers='mock',
+            asset_router_url='mock'
+        )
+
+        self.assertTrue(hasattr(app, "called"))
+
+
+class TestOpenFactoryFastAPIAppAsync(unittest.IsolatedAsyncioTestCase):
+    """
+    Tests for class OpenFactoryFastAPIApp
+    """
+
+    def setUp(self):
+        self.ksql_mock = MagicMock()
+
+        self.asset_producer_patcher = patch("openfactory.assets.asset_base.AssetProducer")
+        self.asset_producer_patcher.start()
+        self.addCleanup(self.asset_producer_patcher.stop)
+
+        self.deregister_patcher = patch('openfactory.apps.ofaapp.deregister_asset')
+        self.deregister_patcher.start()
+        self.addCleanup(self.deregister_patcher.stop)
+
+    async def test_run_openfactory_calls_async_main_loop(self):
+        """ Should call async_main_loop when user overrides it """
+
+        class App(OpenFactoryFastAPIApp):
+            async def async_main_loop(self):
+                self.called = True
+
+        app = App(
+            ksqlClient=self.ksql_mock,
+            bootstrap_servers='mock',
+            asset_router_url='mock'
+        )
+
+        await app._run_openfactory()
+
+        self.assertTrue(hasattr(app, "called"))
+
+    async def test_run_openfactory_waits_when_no_async_main_loop(self):
+        """ Should block when no async_main_loop defined """
+
+        app = OpenFactoryFastAPIApp(
+            ksqlClient=self.ksql_mock,
+            bootstrap_servers='mock',
+            asset_router_url='mock'
+        )
+
+        task = asyncio.create_task(app._run_openfactory())
+
+        await asyncio.sleep(0.01)
+        self.assertFalse(task.done())
+
+        # cancel instead of relying on event
+        task.cancel()
+
+        with self.assertRaises(asyncio.CancelledError):
+            await task
+
+    async def test_run_openfactory_rejects_sync_main_loop(self):
+        """ Should raise if main_loop is defined """
+
+        class App(OpenFactoryFastAPIApp):
+            def main_loop(self):
+                pass
+
+        app = App(
+            ksqlClient=self.ksql_mock,
+            bootstrap_servers='mock',
+            asset_router_url='mock'
+        )
+
+        with self.assertRaises(RuntimeError):
+            await app._run_openfactory()
+
+    def test_run_invokes_async_run(self):
+        """ Test run invokes async_run """
+        app = OpenFactoryFastAPIApp(
+            ksqlClient=self.ksql_mock,
+            bootstrap_servers='mock',
+            asset_router_url='mock'
+        )
+
+        app.async_run = AsyncMock()
+
+        with patch("asyncio.run") as mock_run:
+            app.run()
+
+            mock_run.assert_called_once()
+            # check that asyncio.run was called with the coroutine from async_run
+            coro = mock_run.call_args[0][0]
+            self.assertTrue(asyncio.iscoroutine(coro))
+
+    async def test_async_run_invokes_run_fastapi(self):
+        """ Test async_run invokes _run_fastapi """
+        app = _TestApp(
+            ksqlClient=self.ksql_mock,
+            bootstrap_servers='mock',
+            asset_router_url='mock',
+            test_mode=True
+        )
+
+        app._run_fastapi = AsyncMock()
+
+        await app.async_run()
+
+        app._run_fastapi.assert_awaited_once()
+
+    async def test_async_run_failure_triggers_cleanup(self):
+        """ Test async_run failure triggers cleanup """
+        app = _TestApp(
+            ksqlClient=self.ksql_mock,
+            bootstrap_servers='mock',
+            asset_router_url='mock',
+            test_mode=True
+        )
+
+        async def failing_fastapi():
+            raise RuntimeError("boom")
+
+        app._run_fastapi = failing_fastapi
+        app.app_event_loop_stopped = MagicMock()
+
+        await app.async_run()
+
+        app.app_event_loop_stopped.assert_called_once()
+
+    async def test_uvicorn_shutdown_flag(self):
+        """ Test uvicorn shutdown flag """
+        app = _TestApp(
+            ksqlClient=self.ksql_mock,
+            bootstrap_servers='mock',
+            asset_router_url='mock'
+        )
+
+        class FakeServer:
+            def __init__(self):
+                self.should_exit = False
+
+        app._uvicorn_server = FakeServer()
+        app._run_fastapi = AsyncMock()
+
+        await app.async_run()
+
+        self.assertTrue(app._uvicorn_server.should_exit)
+
+    async def test_default_async_main_loop_cancel(self):
+        """ Ensure default async_main_loop is cancellable """
+        app = OpenFactoryFastAPIApp(
+            ksqlClient=self.ksql_mock,
+            bootstrap_servers='mock',
+            asset_router_url='mock'
+        )
+
+        task = asyncio.create_task(app.async_main_loop())
+
+        await asyncio.sleep(0.01)
+        task.cancel()
+
+        with self.assertRaises(asyncio.CancelledError):
+            await task
+
+    @patch("openfactory.apps.ofa_fastapi_app.uvicorn.Server")
+    @patch("openfactory.apps.ofa_fastapi_app.uvicorn.Config")
+    async def test_run_fastapi_default_port(self, mock_config, mock_server):
+        """ Should use default port 4000 if PORT not set """
+
+        with patch.dict("os.environ", {}, clear=True):
+            app = OpenFactoryFastAPIApp(
+                ksqlClient=self.ksql_mock,
+                bootstrap_servers='mock',
+                asset_router_url='mock'
+            )
+
+            # avoid real serve loop
+            mock_server.return_value.serve = AsyncMock()
+
+            await app._run_fastapi()
+
+            _, kwargs = mock_config.call_args
+            self.assertEqual(kwargs["port"], 4000)
+
+    @patch("openfactory.apps.ofa_fastapi_app.uvicorn.Server")
+    @patch("openfactory.apps.ofa_fastapi_app.uvicorn.Config")
+    async def test_run_fastapi_env_port(self, mock_config, mock_server):
+        """ Should use PORT environment variable """
+
+        with patch.dict("os.environ", {"PORT": "5555"}):
+            app = OpenFactoryFastAPIApp(
+                ksqlClient=self.ksql_mock,
+                bootstrap_servers='mock',
+                asset_router_url='mock'
+            )
+
+            mock_server.return_value.serve = AsyncMock()
+
+            await app._run_fastapi()
+
+            _, kwargs = mock_config.call_args
+            self.assertEqual(kwargs["port"], 5555)

--- a/tests/openfactory/test_openfactorymanager.py
+++ b/tests/openfactory/test_openfactorymanager.py
@@ -193,6 +193,80 @@ class TestOpenFactoryManager(unittest.TestCase):
         self.assertIn(f"traefik.http.routers.{expected_name}.rule", labels)
         self.assertIn(f"traefik.http.services.{expected_name}.loadbalancer.server.port", labels)
 
+    @patch("openfactory.openfactory_manager.register_asset")
+    @patch("openfactory.openfactory_manager.user_notify")
+    def test_deploy_openfactory_application_sets_port_from_routing(self, mock_user_notify, mock_register_asset):
+        """ PORT should be injected when routing is enabled """
+
+        app = OpenFactoryAppSchema(
+            uuid="APP_PORT",
+            image="app_image",
+            environment=["FOO=bar"],
+            routing={
+                "expose": True,
+                "port": 8123,
+                "canonical_hostname": "app.example.com"
+            }
+        )
+
+        self.manager.deploy_openfactory_application(app)
+
+        deploy_call = self.manager.deployment_strategy.deploy.call_args
+        env = deploy_call.kwargs["env"]
+
+        self.assertIn("PORT=8123", env)
+
+    @patch("openfactory.openfactory_manager.user_notify")
+    def test_deploy_openfactory_application_port_conflict(self, mock_user_notify):
+        """ User-defined PORT should cause deployment to fail when routing is enabled """
+
+        app = OpenFactoryAppSchema(
+            uuid="APP_PORT_CONFLICT",
+            image="app_image",
+            environment=["PORT=9999"],
+            routing={
+                "expose": True,
+                "port": 8123
+            }
+        )
+
+        self.manager.deploy_openfactory_application(app)
+
+        # deployment should NOT happen
+        self.manager.deployment_strategy.deploy.assert_not_called()
+
+        # failure must be reported
+        mock_user_notify.fail.assert_called_once()
+        msg = mock_user_notify.fail.call_args[0][0]
+
+        self.assertIn("PORT must not be defined", msg)
+
+    @patch("openfactory.openfactory_manager.register_asset")
+    @patch("openfactory.openfactory_manager.user_notify")
+    def test_deploy_openfactory_application_sets_port_when_routing_not_exposed(self, mock_user_notify, mock_register_asset):
+        """ PORT must be set from routing even if expose=False """
+
+        app = OpenFactoryAppSchema(
+            uuid="APP_PORT_NO_EXPOSE",
+            image="app_image",
+            environment=["FOO=bar"],
+            routing={
+                "expose": False,
+                "port": 8123
+            }
+        )
+
+        self.manager.deploy_openfactory_application(app)
+
+        # ensure deployment happened
+        self.manager.deployment_strategy.deploy.assert_called_once()
+
+        deploy_call = self.manager.deployment_strategy.deploy.call_args
+        env = deploy_call.kwargs["env"]
+
+        self.assertIn("PORT=8123", env)
+        self.assertIn("FOO=bar", env)
+
     @patch("openfactory.openfactory_manager.config")
     @patch("openfactory.openfactory_manager.register_asset")
     @patch("openfactory.openfactory_manager.user_notify")


### PR DESCRIPTION
Add `OpenFactoryFastAPIApp` for integrating FastAPI into OpenFactory applications

Introduce a new class `OpenFactoryFastAPIApp` that extends `OpenFactoryApp` and embeds a FastAPI application.

This allows exposing HTTP endpoints alongside OpenFactory assets, attributes, and methods, while sharing the same lifecycle and runtime.

Key features:
- Provides a `self.api` attribute (FastAPI instance) for defining routes
- Runs FastAPI and the OpenFactory app concurrently in the same asyncio event loop
- Supports optional `async_main_loop` for background tasks (non-blocking)
- Disables `main_loop` (sync loop not compatible with FastAPI runtime)
- Supports modular route definitions via FastAPI routers
- Ensures consistent deployment by aligning container `PORT` with routing configuration

Additional behavior:
- When routing is defined, the container `PORT` is automatically set from `routing.port`
- The `PORT` environment variable is reserved and must not be defined by the user in this case

This enables building web-enabled OpenFactory apps (REST APIs, dashboards, callbacks, etc.) in a clean and consistent way.