### PR TITLE
209 add support for path based routing via openfactory root path

### DIFF
--- a/openfactory/openfactory_manager.py
+++ b/openfactory/openfactory_manager.py
@@ -40,6 +40,7 @@ Important:
     User requires Docker access on the OpenFactory cluster.
 """
 
+import os
 import docker
 import json
 import openfactory.config as config
@@ -142,13 +143,45 @@ class OpenFactoryManager(OpenFactory):
         if routing.alias_hostname:
             rule += f" || Host(`{routing.alias_hostname}`)"
 
-        return {
+        labels = {
             "traefik.enable": "true",
             f"traefik.http.routers.{name}.service": name,
             f"traefik.http.routers.{name}.rule": rule,
             f"traefik.http.routers.{name}.entrypoints": "web",
             f"traefik.http.services.{name}.loadbalancer.server.port": str(routing.port),
         }
+
+        # in development environment add localhost + path-based access
+        if os.environ.get("OPENFACTORY_ENV") == "dev":
+            path_prefix = f"/{normalize_name(application.uuid)}"
+
+            external_router = f"{name}-external"
+            middleware = f"{name}-strip"
+            redirect_middleware = f"{name}-slash"
+
+            labels.update({
+                # external router (localhost + path)
+                f"traefik.http.routers.{external_router}.rule":
+                    f"Host(`localhost`) && PathPrefix(`{path_prefix}`)",
+                f"traefik.http.routers.{external_router}.entrypoints": "web",
+                f"traefik.http.routers.{external_router}.service": name,
+
+                # redirect first, then strip
+                f"traefik.http.routers.{external_router}.middlewares":
+                    f"{redirect_middleware},{middleware}",
+
+                # strip prefix middleware
+                f"traefik.http.middlewares.{middleware}.stripprefix.prefixes":
+                    path_prefix,
+
+                # trailing slash redirect middleware
+                f"traefik.http.middlewares.{redirect_middleware}.redirectregex.regex":
+                    f"^({path_prefix})(\\?.*)?$",
+                f"traefik.http.middlewares.{redirect_middleware}.redirectregex.replacement":
+                    "${1}/${2}",
+            })
+
+        return labels
 
     def deploy_openfactory_application(self, application: OpenFactoryAppSchema) -> None:
         """
@@ -181,6 +214,20 @@ class OpenFactoryManager(OpenFactory):
                             "It is managed automatically by OpenFactory.")
                         return
             env.append(f"PORT={routing.port}")
+
+            # In dev environment, apps are exposed via a path prefix on localhost
+            # (e.g. http://localhost/<app-uuid> using Traefik PathPrefix routing).
+            # To work correctly behind such a prefix, applications must be aware of
+            # their external base path when generating URLs (e.g. links, redirects, API docs, static assets).
+            #
+            # OpenFactory provides this information via OPENFACTORY_ROOT_PATH.
+            # Framework-specific examples:
+            #  - FastAPI:     FastAPI(root_path=...)
+            #  - Flask:       APPLICATION_ROOT / SCRIPT_NAME
+            #  - Django:      FORCE_SCRIPT_NAME
+            #  - WSGI apps:   SCRIPT_NAME
+            if os.environ.get("OPENFACTORY_ENV") == "dev":
+                env.append(f"OPENFACTORY_ROOT_PATH=/{normalize_name(application.uuid)}")
 
         # Add STORAGE only if not None
         if application.storage is not None:

--- a/tests/openfactory/test_openfactorymanager.py
+++ b/tests/openfactory/test_openfactorymanager.py
@@ -193,6 +193,65 @@ class TestOpenFactoryManager(unittest.TestCase):
         self.assertIn(f"traefik.http.routers.{expected_name}.rule", labels)
         self.assertIn(f"traefik.http.services.{expected_name}.loadbalancer.server.port", labels)
 
+    @patch.dict("os.environ", {"OPENFACTORY_ENV": "dev"})
+    def test_build_traefik_labels_dev_mode_adds_path_prefix(self):
+        """ Test that _build_traefik_labels adds path prefixes in dev environment """
+        app = OpenFactoryAppSchema(
+            uuid="APP123",
+            image="demo",
+            routing={
+                "expose": True,
+                "port": 8000,
+                "canonical_hostname": "app.example.com"
+            }
+        )
+
+        labels = self.manager._build_traefik_labels(app)
+
+        name = "ofa-app123"
+        path_prefix = "/app123"
+
+        # external router exists
+        self.assertIn(f"traefik.http.routers.{name}-external.rule", labels)
+
+        self.assertEqual(
+            labels[f"traefik.http.routers.{name}-external.rule"],
+            f"Host(`localhost`) && PathPrefix(`{path_prefix}`)"
+        )
+
+        # middleware chain
+        self.assertIn(
+            f"traefik.http.routers.{name}-external.middlewares",
+            labels
+        )
+
+        # strip prefix middleware
+        self.assertEqual(
+            labels[f"traefik.http.middlewares.{name}-strip.stripprefix.prefixes"],
+            path_prefix
+        )
+
+    @patch.dict("os.environ", {}, clear=True)
+    def test_build_traefik_labels_no_dev_mode_no_path_prefix(self):
+        """ Test that _build_traefik_labels does not add path prefixes when not in dev environment """
+        app = OpenFactoryAppSchema(
+            uuid="APP123",
+            image="demo",
+            routing={
+                "expose": True,
+                "port": 8000,
+                "canonical_hostname": "app.example.com"
+            }
+        )
+
+        labels = self.manager._build_traefik_labels(app)
+
+        # external router must NOT exist
+        self.assertNotIn(
+            "traefik.http.routers.ofa-app123-external.rule",
+            labels
+        )
+
     @patch("openfactory.openfactory_manager.register_asset")
     @patch("openfactory.openfactory_manager.user_notify")
     def test_deploy_openfactory_application_sets_port_from_routing(self, mock_user_notify, mock_register_asset):
@@ -266,6 +325,52 @@ class TestOpenFactoryManager(unittest.TestCase):
 
         self.assertIn("PORT=8123", env)
         self.assertIn("FOO=bar", env)
+
+    @patch.dict("os.environ", {"OPENFACTORY_ENV": "dev"})
+    @patch("openfactory.openfactory_manager.register_asset")
+    @patch("openfactory.openfactory_manager.user_notify")
+    def test_deploy_openfactory_application_sets_openfactory_root_path_in_dev(self, mock_user_notify, mock_register_asset):
+        """ Test that deploy_openfactory_application sets OPENFACTORY_ROOT_PATH in dev environment """
+        app = OpenFactoryAppSchema(
+            uuid="APP123",
+            image="app_image",
+            routing={
+                "expose": True,
+                "port": 8000,
+                "canonical_hostname": "app.example.com"
+            }
+        )
+
+        self.manager.deploy_openfactory_application(app)
+
+        deploy_call = self.manager.deployment_strategy.deploy.call_args
+        env = deploy_call.kwargs["env"]
+
+        self.assertIn("OPENFACTORY_ROOT_PATH=/app123", env)
+
+    @patch.dict("os.environ", {}, clear=True)
+    @patch("openfactory.openfactory_manager.register_asset")
+    @patch("openfactory.openfactory_manager.user_notify")
+    def test_deploy_openfactory_application_does_not_set_openfactory_root_path_outside_dev(self, mock_user_notify, mock_register_asset):
+        """ Test that deploy_openfactory_application does not set OPENFACTORY_ROOT_PATH when not in dev environment """
+        app = OpenFactoryAppSchema(
+            uuid="APP123",
+            image="app_image",
+            routing={
+                "expose": True,
+                "port": 8000,
+                "canonical_hostname": "app.example.com"
+            }
+        )
+
+        self.manager.deploy_openfactory_application(app)
+
+        deploy_call = self.manager.deployment_strategy.deploy.call_args
+        env = deploy_call.kwargs["env"]
+
+        self.assertFalse(
+            any(e.startswith("OPENFACTORY_ROOT_PATH=") for e in env)
+        )
 
     @patch("openfactory.openfactory_manager.config")
     @patch("openfactory.openfactory_manager.register_asset")


### PR DESCRIPTION
Add support for path-based routing via `OPENFACTORY_ROOT_PATH`

### Summary

This PR introduces support for applications exposed via **path-based routing** (e.g. `http://localhost/<app-name>`) by injecting a new environment variable:

```text
OPENFACTORY_ROOT_PATH=/<app-name>
```

This enables applications (FastAPI, Flask, Django, etc.) to correctly handle URL generation when deployed behind a reverse proxy using `PathPrefix`.

---

## 🧠 Background

OpenFactory supports two routing modes:

1. **Host-based routing**
   ```
   http://myapp.openfactory.local
   ```
   → No path prefix

2. **Path-based routing (dev / localhost)**
   ```
   http://localhost/myapp
   ```
   → Requires application awareness of base path

Without this change, applications exposed via `PathPrefix` may exhibit:

* Broken Swagger/OpenAPI (`/openapi.json` not found)
* Incorrect redirects
* Invalid relative URLs

## Changes

### 1. Inject `OPENFACTORY_ROOT_PATH` in dev mode

This provides applications with their **external mount path**.

### 2. Extend Traefik labels for path-based routing

In `_build_traefik_labels`:

* Added external router:

  ```text
  Host(`localhost`) && PathPrefix(`/<app-name>`)
  ```

* Added middleware chain:

  * `redirectregex` → ensures trailing slash
  * `stripprefix` → removes path before forwarding


## 🧾 Usage (for app developers)

Applications can read:

```python
root_path = os.getenv("OPENFACTORY_ROOT_PATH", "")
```

Example (FastAPI):

```python
app = FastAPI(
    root_path=root_path,
    root_path_in_servers=True,
)
```

## Result

Applications now work correctly under both:

* `http://myapp.openfactory.local` ✅
* `http://localhost/myapp` ✅
