### PR TITLE
Make FastAPI app import optional in openfactory.apps

### DIFF
--- a/openfactory/apps/__init__.py
+++ b/openfactory/apps/__init__.py
@@ -1,6 +1,36 @@
 """ OpenFactory apps module. """
 
 from openfactory.apps.ofaapp import OpenFactoryApp
-from openfactory.apps.ofa_fastapi_app import OpenFactoryFastAPIApp
 from openfactory.apps.decorators import ofa_method
 from openfactory.apps.attributefield import AttributeField, EventAttribute, SampleAttribute
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from openfactory.apps.ofa_fastapi_app import OpenFactoryFastAPIApp
+
+
+__all__ = [
+    "OpenFactoryApp",
+    "ofa_method",
+    "AttributeField",
+    "EventAttribute",
+    "SampleAttribute",
+    "OpenFactoryFastAPIApp",
+]
+
+
+def __getattr__(name):
+    if name == "OpenFactoryFastAPIApp":
+        try:
+            from openfactory.apps.ofa_fastapi_app import OpenFactoryFastAPIApp
+        except ImportError as e:
+            raise ImportError(
+                "OpenFactoryFastAPIApp requires optional dependencies. "
+                "Install it with `pip install openfactory[fastapi]`."
+            ) from e
+
+        globals()[name] = OpenFactoryFastAPIApp  # cache it
+        return OpenFactoryFastAPIApp
+
+    raise AttributeError(f"module {__name__} has no attribute {name}")


### PR DESCRIPTION
**Summary:**

Avoid importing `OpenFactoryFastAPIApp` at module import time to prevent requiring FastAPI for users who only need the core `OpenFactoryApp`.

**Changes:**

* Removed eager import of `OpenFactoryFastAPIApp` from `openfactory.apps.__init__`
* Added lazy import via `__getattr__`
* Added clear error message when optional dependencies are missing
* Declared `OpenFactoryFastAPIApp` in `__all__`
* Added `TYPE_CHECKING` import for editor/type support

**Before:**

Importing the module required FastAPI to be installed:

```python
from openfactory.apps import OpenFactoryApp
```

→ could fail if FastAPI was not installed

**After:**

* `OpenFactoryApp` works without FastAPI
* `OpenFactoryFastAPIApp` is only imported when explicitly accessed
* Missing dependencies produce a clear, actionable error

**Example:**

```python
from openfactory.apps import OpenFactoryApp  # works without FastAPI

from openfactory.apps import OpenFactoryFastAPIApp
# raises helpful error if fastapi extra is not installed
```

**Optional dependencies:**

```bash
pip install openfactory[fastapi]
```

**Notes:**

This change maintains backward compatibility for users importing `OpenFactoryFastAPIApp` while removing an unintended hard dependency.
