### PR TITLE
232 the assetforwarder must handle case insensitive id keys

### DIFF
--- a/openfactory/fanoutlayer/asset_forwarder/asset_forwarder.py
+++ b/openfactory/fanoutlayer/asset_forwarder/asset_forwarder.py
@@ -368,7 +368,8 @@ class AssetForwarder:
             cluster = self.nats_clusters[cluster_name]
 
             # Extract and remove ID safely
-            message_id = value.pop("ID", None)
+            id_key = next((k for k in value.keys() if k.lower() == "id"), None)
+            message_id = value.pop(id_key, None) if id_key else None
             if not message_id:
                 logger.warning(f"[{worker_id}] ID missing in {value}")
                 self.queue.task_done()
@@ -382,15 +383,16 @@ class AssetForwarder:
 
             # Publish with retry
             ok = await self._publish_with_retry(cluster, subject, payload_bytes)
-            logger.debug(f"Worker[{worker_id}] Published msg (partition={envelope['partition']}, offset={envelope['msg_offset']}) to {cluster_name} in subject {subject}")
 
             if ok:
                 forwarder_metrics.NATS_MESSAGES_PUBLISHED.labels(cluster=cluster_name).inc()
                 # mark message as processed
                 tp = TopicPartition(envelope["topic"], envelope["partition"], envelope["msg_offset"] + 1)
                 self.consumer.store_offsets(offsets=[tp])
+                logger.debug(f"Worker[{worker_id}] Published msg {json.dumps(value)} (partition={envelope['partition']}, offset={envelope['msg_offset']}) to {cluster_name} in subject {subject}")
             else:
                 forwarder_metrics.NATS_PUBLISH_FAILURES.labels(cluster=cluster_name).inc()
+                logger.warning(f"Worker[{worker_id}] NATS cluster failed to accept msg ({json.dumps(value)}) to {cluster_name} in subject {subject}")
 
             duration = time.perf_counter() - start_time
             forwarder_metrics.MESSAGE_PROCESSING_LATENCY.labels(forwarder=self.forwarder_id).observe(duration)

--- a/tests/openfactory/fanoutlayer/asset_forwarder/test_asset_forwarder.py
+++ b/tests/openfactory/fanoutlayer/asset_forwarder/test_asset_forwarder.py
@@ -72,6 +72,94 @@ class TestAssetForwarder(unittest.IsolatedAsyncioTestCase):
         # that call returns a coroutine (not awaited). Check it was at least called:
         self.assertTrue(self.forwarder.consumer.store_offsets.called)
 
+    async def test_worker_accepts_case_insensitive_id(self):
+        """ Test that worker accepts ID keys in any casing. """
+        value = {"Id": "msg1", "foo": "bar"}
+
+        envelope = {
+            "topic": "ofa_assets",
+            "partition": 0,
+            "msg_offset": 1,
+            "key": b"asset123",
+            "value": value,
+            "enqueue_ts": time.perf_counter(),
+        }
+
+        await self.forwarder.queue.put(envelope)
+        await self.forwarder.queue.put(None)
+
+        worker_task = asyncio.create_task(self.forwarder._worker(0))
+
+        try:
+            await self.forwarder.queue.join()
+        finally:
+            worker_task.cancel()
+            with suppress(asyncio.CancelledError):
+                await worker_task
+
+        cluster_name = self.forwarder.hash_ring.get(envelope["key"])
+
+        expected_subject = "asset123.msg1"
+        expected_payload = json.dumps({"foo": "bar"}).encode()
+
+        cluster_mock = self.forwarder.nats_clusters[cluster_name]
+
+        cluster_mock.publish.assert_awaited_once_with(
+            expected_subject,
+            expected_payload,
+        )
+
+        # Ensure the original mixed-case key was removed from payload
+        published_payload = json.loads(
+            cluster_mock.publish.await_args[0][1].decode()
+        )
+
+        self.assertNotIn("Id", published_payload)
+
+    async def test_worker_logs_warning_when_id_missing_in_any_case(self):
+        """ Test worker logs warning and skips publish when no ID field exists. """
+
+        value = {
+            "foo": "bar",
+            "identifier": "not-valid",
+            "message_id": "also-not-valid",
+        }
+
+        envelope = {
+            "topic": "ofa_assets",
+            "partition": 0,
+            "msg_offset": 1,
+            "key": b"asset123",
+            "value": value,
+            "enqueue_ts": time.perf_counter(),
+        }
+
+        await self.forwarder.queue.put(envelope)
+        await self.forwarder.queue.put(None)
+
+        with patch(
+            "openfactory.fanoutlayer.asset_forwarder.asset_forwarder.logger.warning"
+        ) as mock_warning:
+
+            worker_task = asyncio.create_task(self.forwarder._worker(0))
+
+            try:
+                await self.forwarder.queue.join()
+            finally:
+                worker_task.cancel()
+                with suppress(asyncio.CancelledError):
+                    await worker_task
+
+        # Ensure warning was logged
+        mock_warning.assert_called()
+
+        warning_msg = mock_warning.call_args[0][0]
+        self.assertIn("ID missing", warning_msg)
+
+        # Ensure nothing was published
+        for cluster in self.forwarder.nats_clusters.values():
+            cluster.publish.assert_not_awaited()
+
     async def test_worker_skips_message_without_key(self):
         """ Test worker skips messages without a key. """
         envelope = {


### PR DESCRIPTION
The `AssetForwarder` now handles case insensitive `ID` fields in the Kafka messages.

This is important as for example MTConnect will produce `id` in lowercase whereas for example the OPC UA Gateways produce `ID` in uppercase.