### PR TITLE
234 the asset subscriptions methods must handle filtering using case insensitive field for asset attribute type

### DIFF
--- a/openfactory/assets/asset_base.py
+++ b/openfactory/assets/asset_base.py
@@ -791,7 +791,8 @@ class BaseAsset:
         subject = f"{self.asset_uuid.upper()}.*"
 
         def _filter_samples(msg_subject: str, msg_value: dict):
-            if msg_value.get("TYPE") == "Samples":
+            msg_value = CaseInsensitiveDict(msg_value)
+            if msg_value.get("TYPE").upper() == "SAMPLES":
                 on_sample(msg_subject, msg_value)
 
         self.__start_nats_consumer(subject, _filter_samples, sub_key="samples")
@@ -810,7 +811,8 @@ class BaseAsset:
         subject = f"{self.asset_uuid.upper()}.*"
 
         def _filter_events(msg_subject: str, msg_value: dict):
-            if msg_value.get("TYPE") == "Events":
+            msg_value = CaseInsensitiveDict(msg_value)
+            if msg_value.get("TYPE").upper() == "EVENTS":
                 on_event(msg_subject, msg_value)
 
         self.__start_nats_consumer(subject, _filter_events, sub_key="events")
@@ -829,7 +831,8 @@ class BaseAsset:
         subject = f"{self.asset_uuid.upper()}.*"
 
         def _filter_conditions(msg_subject: str, msg_value: dict):
-            if msg_value.get("TYPE") == "Condition":
+            msg_value = CaseInsensitiveDict(msg_value)
+            if msg_value.get("TYPE").upper() == "CONDITION":
                 on_condition(msg_subject, msg_value)
 
         self.__start_nats_consumer(subject, _filter_conditions, sub_key="conditions")

--- a/tests/openfactory/assets/test_baseasset.py
+++ b/tests/openfactory/assets/test_baseasset.py
@@ -922,7 +922,7 @@ class TestBaseAsset(TestCase):
             filter = args[1]
 
             # Should call callback for TYPE == 'Samples'
-            sample_msg = {"TYPE": "Samples", "VALUE": 123}
+            sample_msg = {"tYpe": "SampleS", "VALUE": 123}
             filter("subject.test", sample_msg)
             callback.assert_called_once_with("subject.test", sample_msg)
 
@@ -959,7 +959,7 @@ class TestBaseAsset(TestCase):
             filter_fn = args[1]
 
             # Should call callback for TYPE == 'Events'
-            event_msg = {"TYPE": "Events", "VALUE": 123}
+            event_msg = {"TYpe": "EvEnts", "VALUE": 123}
             filter_fn("subject.test", event_msg)
             callback.assert_called_once_with("subject.test", event_msg)
 
@@ -998,7 +998,7 @@ class TestBaseAsset(TestCase):
             filter_fn = args[1]
 
             # Should call callback for TYPE == 'Condition'
-            condition_msg = {"TYPE": "Condition", "VALUE": 123}
+            condition_msg = {"tyPE": "CondiTion", "VALUE": 123}
             filter_fn("subject.test", condition_msg)
             callback.assert_called_once_with("subject.test", condition_msg)
 


### PR DESCRIPTION
The `Asset` subscriptions methods now handle filtering using case insensitive field for `AssetAttribute` Type.