### PR TITLE
238 add support for runtime uidgid configuration for openfactory applications

### DIFF
--- a/openfactory/openfactory_deploy_strategy.py
+++ b/openfactory/openfactory_deploy_strategy.py
@@ -17,6 +17,8 @@ Key Components:
 Features:
 ---------
 - Unified interface for deploying and removing OpenFactory services.
+- Supports optional runtime UID/GID configuration for compatibility with shared
+  filesystems such as NFS.
 - Supports environment variables, container commands, labels, ports, networks,
   constraints, resource limits, and Docker mounts.
 - Converts backend mount specifications (Local, NFS, Volume) into Docker-compatible mounts.
@@ -32,6 +34,7 @@ Usage Example:
     local_strategy.deploy(
         image="ghcr.io/openfactoryio/scheduler:v1.0.0",
         name="scheduler",
+        user="1234:5678",
         env=["ENV=production"],
         mounts=[{
             "Type": "bind",
@@ -46,6 +49,7 @@ Usage Example:
     swarm_strategy.deploy(
         image="ghcr.io/openfactoryio/reporter:v1.0.0",
         name="reporter",
+        user="1234:5678",
         env=["LOG_LEVEL=info"],
         mounts=[{
             "Type": "nfs",
@@ -75,6 +79,7 @@ class OpenFactoryServiceDeploymentStrategy(ABC):
     @abstractmethod
     def deploy(self, *,
                image: str,
+               user: Optional[str] = None,
                name: str,
                env: List[str],
                labels: Optional[Dict[str, str]] = None,
@@ -90,6 +95,7 @@ class OpenFactoryServiceDeploymentStrategy(ABC):
 
         Args:
             image (str): Docker image to deploy.
+            user (Optional[str]): Runtime user in Docker format ``UID:GID``.
             name (str): Name of the service or container.
             env (List[str]): Environment variables in `KEY=VALUE` format.
             labels (Optional[Dict[str, str]]): Metadata labels (Swarm only).
@@ -119,6 +125,7 @@ class SwarmDeploymentStrategy(OpenFactoryServiceDeploymentStrategy):
 
     def deploy(self, *,
                image: str,
+               user: Optional[str] = None,
                name: str,
                env: List[str],
                labels: Optional[Dict[str, str]] = None,
@@ -136,6 +143,7 @@ class SwarmDeploymentStrategy(OpenFactoryServiceDeploymentStrategy):
         """
         dal.docker_client.services.create(
             image=image,
+            user=user,
             name=name,
             env=env,
             labels=labels,
@@ -198,6 +206,7 @@ class LocalDockerDeploymentStrategy(OpenFactoryServiceDeploymentStrategy):
 
     def deploy(self, *,
                image: str,
+               user: Optional[str] = None,
                name: str,
                env: List[str],
                labels: Optional[Dict[str, str]] = None,
@@ -234,6 +243,7 @@ class LocalDockerDeploymentStrategy(OpenFactoryServiceDeploymentStrategy):
 
         container = client.containers.run(
             image=image,
+            user=user,
             name=name,
             environment=env,
             command=command,

--- a/openfactory/openfactory_manager.py
+++ b/openfactory/openfactory_manager.py
@@ -193,6 +193,14 @@ class OpenFactoryManager(OpenFactory):
         Raises:
             OFAException: If the application cannot be deployed.
         """
+        # runtime user override
+        runtime_user = None
+
+        if application.runtime_uid is not None:
+            runtime_user = (
+                f"{application.runtime_uid}:{application.runtime_gid}"
+            )
+
         # build environment variables
         env = [f"APP_UUID={application.uuid}",
                f"KAFKA_BROKER={self.bootstrap_servers}",
@@ -258,6 +266,7 @@ class OpenFactoryManager(OpenFactory):
         try:
             self.deployment_strategy.deploy(
                 image=application.image,
+                user=runtime_user,
                 name=application.uuid.lower(),
                 mode={"Replicated": {"Replicas": 1}},
                 env=env,

--- a/openfactory/schemas/apps.py
+++ b/openfactory/schemas/apps.py
@@ -46,6 +46,8 @@ configuration YAML file, with automatic UNS enrichment.
         scheduler:
           uuid: "app-scheduler"
           image: ghcr.io/openfactoryio/scheduler:v1.0.0
+          runtime_uid: 1234
+          runtime_gid: 5678
 
           uns:
             location: building-a
@@ -100,7 +102,7 @@ Note:
 
 import re
 import openfactory.config as Config
-from pydantic import BaseModel, Field, ValidationError, ConfigDict, field_validator
+from pydantic import BaseModel, Field, ValidationError, ConfigDict, field_validator, model_validator
 from typing import List, Dict, Optional, Any
 from openfactory.config import load_yaml
 from openfactory.models.user_notifications import user_notify
@@ -248,6 +250,18 @@ class OpenFactoryAppSchema(AttachUNSMixin, BaseModel):
 
     image: str = Field(..., description="Docker image for the app")
 
+    runtime_uid: Optional[int] = Field(
+        default=None,
+        ge=1,
+        description="Optional runtime UID used to run the container process"
+    )
+
+    runtime_gid: Optional[int] = Field(
+        default=None,
+        ge=1,
+        description="Optional runtime GID used to run the container process"
+    )
+
     environment: Optional[List[str]] = Field(
         default=None, description="List of environment variables"
     )
@@ -282,6 +296,14 @@ class OpenFactoryAppSchema(AttachUNSMixin, BaseModel):
                 if not name.strip():
                     raise ValueError("Network names must not be empty")
         return v
+
+    @model_validator(mode="after")
+    def validate_runtime_user(self):
+        if (self.runtime_uid is None) != (self.runtime_gid is None):
+            raise ValueError(
+                "runtime_uid and runtime_gid must either both be defined or both be omitted"
+            )
+        return self
 
 
 class OpenFactoryAppsConfig(BaseModel):

--- a/tests/openfactory/schemas/test_apps.py
+++ b/tests/openfactory/schemas/test_apps.py
@@ -121,6 +121,135 @@ class TestOpenFactoryAppsConfig(unittest.TestCase):
 
         self.assertIn("apps", str(context.exception))
 
+    def test_runtime_uid_gid_valid(self):
+        """ runtime_uid and runtime_gid are parsed correctly """
+
+        valid_config = {
+            "apps": {
+                "demo1": {
+                    "uuid": "DEMO-APP",
+                    "image": "demofact/demo1",
+                    "runtime_uid": 1234,
+                    "runtime_gid": 5678
+                }
+            }
+        }
+
+        config = OpenFactoryAppsConfig(**valid_config)
+
+        app = config.apps["demo1"]
+
+        self.assertEqual(app.runtime_uid, 1234)
+        self.assertEqual(app.runtime_gid, 5678)
+
+    def test_runtime_uid_without_gid_invalid(self):
+        """ runtime_uid without runtime_gid should raise ValidationError """
+
+        invalid_config = {
+            "apps": {
+                "demo1": {
+                    "uuid": "DEMO-APP",
+                    "image": "demofact/demo1",
+                    "runtime_uid": 1234
+                }
+            }
+        }
+
+        with self.assertRaises(ValidationError) as cm:
+            OpenFactoryAppsConfig(**invalid_config)
+
+        self.assertIn(
+            "runtime_uid and runtime_gid must either both be defined or both be omitted",
+            str(cm.exception)
+        )
+
+    def test_runtime_gid_without_uid_invalid(self):
+        """ runtime_gid without runtime_uid should raise ValidationError """
+
+        invalid_config = {
+            "apps": {
+                "demo1": {
+                    "uuid": "DEMO-APP",
+                    "image": "demofact/demo1",
+                    "runtime_gid": 5678
+                }
+            }
+        }
+
+        with self.assertRaises(ValidationError) as cm:
+            OpenFactoryAppsConfig(**invalid_config)
+
+        self.assertIn(
+            "runtime_uid and runtime_gid must either both be defined or both be omitted",
+            str(cm.exception)
+        )
+
+    def test_runtime_uid_zero_invalid(self):
+        """ runtime_uid must be >= 1 """
+
+        invalid_config = {
+            "apps": {
+                "demo1": {
+                    "uuid": "DEMO-APP",
+                    "image": "demofact/demo1",
+                    "runtime_uid": 0,
+                    "runtime_gid": 5678
+                }
+            }
+        }
+
+        with self.assertRaises(ValidationError) as cm:
+            OpenFactoryAppsConfig(**invalid_config)
+
+        self.assertIn("greater than or equal to 1", str(cm.exception))
+
+    def test_runtime_gid_zero_invalid(self):
+        """ runtime_gid must be >= 1 """
+
+        invalid_config = {
+            "apps": {
+                "demo1": {
+                    "uuid": "DEMO-APP",
+                    "image": "demofact/demo1",
+                    "runtime_uid": 1234,
+                    "runtime_gid": 0
+                }
+            }
+        }
+
+        with self.assertRaises(ValidationError) as cm:
+            OpenFactoryAppsConfig(**invalid_config)
+
+        self.assertIn("greater than or equal to 1", str(cm.exception))
+
+    @patch("openfactory.schemas.apps.load_yaml")
+    def test_runtime_uid_gid_integration_with_get_apps_from_config_file(self, mock_load_yaml):
+        """ runtime_uid and runtime_gid are correctly parsed from YAML """
+
+        mock_load_yaml.return_value = {
+            "apps": {
+                "demo1": {
+                    "uuid": "DEMO-APP",
+                    "uns": {"workcenter": "WC2"},
+                    "image": "demofact/demo1",
+                    "runtime_uid": 1234,
+                    "runtime_gid": 5678
+                }
+            }
+        }
+
+        result = get_apps_from_config_file(
+            "dummy.yaml",
+            self.uns_schema
+        )
+
+        self.assertIsNotNone(result)
+
+        app = result["demo1"]
+
+        self.assertEqual(app.runtime_uid, 1234)
+        self.assertEqual(app.runtime_gid, 5678)
+
     def test_invalid_environment_type(self):
         """ Test invalid environment type (string instead of list) """
         invalid_config = {

--- a/tests/openfactory/test_openfactory_deploy_strategy.py
+++ b/tests/openfactory/test_openfactory_deploy_strategy.py
@@ -41,6 +41,29 @@ class TestSwarmDeploymentStrategy(unittest.TestCase):
         self.assertEqual(kwargs["resources"]["Limits"]["NanoCPUs"], 500000000)
         self.assertEqual(kwargs["mode"], {"Replicated": {"Replicas": 2}})
 
+    @patch("openfactory.openfactory_deploy_strategy.dal.docker_client")
+    def test_swarm_deploy_with_runtime_user(self, mock_docker_client):
+        """ Test Docker Swarm deploy with runtime user """
+
+        mock_create = MagicMock()
+        mock_docker_client.services.create = mock_create
+
+        strategy = SwarmDeploymentStrategy()
+
+        strategy.deploy(
+            image="test-image",
+            name="test-service",
+            env=["ENV=prod"],
+            user="1234:5678"
+        )
+
+        mock_create.assert_called_once()
+
+        _, kwargs = mock_create.call_args
+
+        self.assertIn("user", kwargs)
+        self.assertEqual(kwargs["user"], "1234:5678")
+
     @patch("openfactory.openfactory_deploy_strategy.docker.types.Mount")
     @patch("openfactory.openfactory_deploy_strategy.dal.docker_client")
     def test_swarm_deploy_with_mounts(self, mock_docker_client, mock_mount_class):
@@ -127,6 +150,32 @@ class TestLocalDockerDeploymentStrategy(unittest.TestCase):
         self.assertEqual(kwargs["network"], "bridge")
         self.assertEqual(kwargs["labels"], {"type": "api"})
         self.assertEqual(kwargs["nano_cpus"], 1000000000)
+
+    @patch("openfactory.openfactory_deploy_strategy.docker.from_env")
+    def test_local_deploy_with_runtime_user(self, mock_from_env):
+        """ Test local Docker deploy with runtime user """
+
+        mock_client = MagicMock()
+        mock_run = MagicMock()
+
+        mock_client.containers.run = mock_run
+        mock_from_env.return_value = mock_client
+
+        strategy = LocalDockerDeploymentStrategy()
+
+        strategy.deploy(
+            image="test-image",
+            name="test-container",
+            env=["ENV=dev"],
+            user="1234:5678"
+        )
+
+        mock_run.assert_called_once()
+
+        _, kwargs = mock_run.call_args
+
+        self.assertIn("user", kwargs)
+        self.assertEqual(kwargs["user"], "1234:5678")
 
     @patch("openfactory.openfactory_deploy_strategy.docker.from_env")
     def test_local_remove(self, mock_from_env):

--- a/tests/openfactory/test_openfactorymanager.py
+++ b/tests/openfactory/test_openfactorymanager.py
@@ -435,6 +435,42 @@ class TestOpenFactoryManager(unittest.TestCase):
 
     @patch("openfactory.openfactory_manager.register_asset")
     @patch("openfactory.openfactory_manager.user_notify")
+    def test_deploy_openfactory_application_runtime_user(self, mock_user_notify, mock_register_asset):
+        """ runtime UID/GID should be passed to deployment strategy """
+        app = OpenFactoryAppSchema(
+            uuid="APP_RUNTIME_USER",
+            image="app_image",
+            runtime_uid=1234,
+            runtime_gid=5678
+        )
+
+        self.manager.deploy_openfactory_application(app)
+
+        deploy_call = self.manager.deployment_strategy.deploy.call_args
+        kwargs = deploy_call.kwargs
+
+        self.assertIn("user", kwargs)
+        self.assertEqual(kwargs["user"], "1234:5678")
+
+    @patch("openfactory.openfactory_manager.register_asset")
+    @patch("openfactory.openfactory_manager.user_notify")
+    def test_deploy_openfactory_application_no_runtime_user(self, mock_user_notify, mock_register_asset):
+        """ user should be None when runtime UID/GID are omitted """
+        app = OpenFactoryAppSchema(
+            uuid="APP_NO_RUNTIME_USER",
+            image="app_image"
+        )
+
+        self.manager.deploy_openfactory_application(app)
+
+        deploy_call = self.manager.deployment_strategy.deploy.call_args
+        kwargs = deploy_call.kwargs
+
+        self.assertIn("user", kwargs)
+        self.assertIsNone(kwargs["user"])
+
+    @patch("openfactory.openfactory_manager.register_asset")
+    @patch("openfactory.openfactory_manager.user_notify")
     def test_deploy_openfactory_application_includes_resources(self, mock_user_notify, mock_register_asset):
         """ Test that resources() result is passed to deploy when Deploy has limits and reservations. """
         res = Resources(


### PR DESCRIPTION
# Add runtime UID/GID support for OpenFactory application deployments

## Summary

This PR adds support for configuring runtime UID/GID for OpenFactory application containers.

Applications can now specify:

```yaml
runtime_uid: 1234
runtime_gid: 5678
```

which is propagated through deployment strategies and translated into Docker/Swarm runtime user configuration.

This enables cleaner deployment of applications using:

* NFS-backed storage
* shared NAS volumes
* enterprise multi-user environments
* external filesystem permission models

without requiring image rebuilds or custom entrypoint scripts.

## Schema Changes

`OpenFactoryAppSchema` now supports:

* `runtime_uid`
* `runtime_gid`

Validation rules:

* both fields must either be defined together or omitted
* values must be `>= 1`

Example:

```yaml
apps:
  scheduler:
    uuid: "app-scheduler"
    image: ghcr.io/openfactoryio/scheduler:v1.0.0

    runtime_uid: 1234
    runtime_gid: 5678
```

## Deployment Changes

The runtime user is propagated through:

* `OpenFactoryManager`
* `OpenFactoryServiceDeploymentStrategy`

and implemented in:

* `LocalDockerDeploymentStrategy`
* `SwarmDeploymentStrategy`

using native Docker `user=UID:GID` runtime configuration.

## Documentation

Updated deployment strategy documentation to include:

* runtime UID/GID support
* NFS/shared filesystem motivation
* updated deployment examples

## Testing

Added unit tests for:

* schema validation
* YAML parsing
* deployment propagation
* Docker local deployment
* Docker Swarm deployment
* default behavior when runtime user is omitted
