### PR TITLE
240 flask redirects broken behind traefik path prefix routing

### DIFF
--- a/openfactory/apps/ofa_flask_app.py
+++ b/openfactory/apps/ofa_flask_app.py
@@ -173,6 +173,8 @@ class OpenFactoryFlaskApp(OpenFactoryApp):
       - OpenFactory features such as attributes, methods, and asset communication remain unchanged.
       - When deployed on the OpenFactory platform, the ``PORT`` environment variable is set automatically
         by the deployment tool.
+      - OpenFactory automatically enables Werkzeug ProxyFix to support reverse-proxy deployments through
+        the OpenFactory Traefik routing gateway, including localhost path-prefix routing in development mode.
 
     .. seealso::
         - :class:`openfactory.apps.ofaapp.OpenFactoryApp`

--- a/openfactory/apps/ofa_flask_app.py
+++ b/openfactory/apps/ofa_flask_app.py
@@ -10,6 +10,7 @@ import os
 import asyncio
 import threading
 from werkzeug.serving import make_server
+from werkzeug.middleware.proxy_fix import ProxyFix
 from openfactory.apps import OpenFactoryApp
 from openfactory.kafka import KSQLDBClient
 
@@ -224,6 +225,24 @@ class OpenFactoryFlaskApp(OpenFactoryApp):
 
         # Flask application
         self.app = self.create_flask_app()
+
+        # Trust reverse proxy forwarded headers.
+        #
+        # Required for correct URL generation and redirects when
+        # applications are exposed behind a path prefix through
+        # the OpenFactory Traefik development gateway:
+        #
+        #   http://localhost/<app-name>/
+        #
+        # Traefik StripPrefix forwards the original external
+        # prefix via X-Forwarded-Prefix, which Werkzeug maps
+        # to SCRIPT_NAME through ProxyFix.
+        self.app.wsgi_app = ProxyFix(
+            self.app.wsgi_app,
+            x_prefix=1,
+            x_host=1,
+            x_proto=1,
+        )
 
         # expose OpenFactory app inside Flask
         self.app.ofa_app = self

--- a/tests/openfactory/apps/test_openfactory_flask_app.py
+++ b/tests/openfactory/apps/test_openfactory_flask_app.py
@@ -61,6 +61,33 @@ class TestOpenFactoryFlaskApp(unittest.TestCase):
 
         self.assertTrue(hasattr(app, "called"))
 
+    def test_proxyfix_enabled(self):
+        """ Flask app should enable ProxyFix middleware """
+
+        app = OpenFactoryFlaskApp(
+            ksqlClient=self.ksql_mock,
+            bootstrap_servers="mock",
+            asset_router_url="mock"
+        )
+
+        from werkzeug.middleware.proxy_fix import ProxyFix
+        self.assertIsInstance(app.app.wsgi_app, ProxyFix)
+
+    def test_proxyfix_configuration(self):
+        """ Flask app should configure ProxyFix correctly """
+
+        app = OpenFactoryFlaskApp(
+            ksqlClient=self.ksql_mock,
+            bootstrap_servers="mock",
+            asset_router_url="mock"
+        )
+
+        from werkzeug.middleware.proxy_fix import ProxyFix
+        self.assertIsInstance(app.app.wsgi_app, ProxyFix)
+        self.assertEqual(app.app.wsgi_app.x_prefix, 1)
+        self.assertEqual(app.app.wsgi_app.x_host, 1)
+        self.assertEqual(app.app.wsgi_app.x_proto, 1)
+
     def test_configure_routes_called(self):
         """ Test initialization calls configure_routes """
 

--- a/tests/openfactory/apps/test_openfactory_flask_app_http.py
+++ b/tests/openfactory/apps/test_openfactory_flask_app_http.py
@@ -88,3 +88,22 @@ class TestOpenFactoryFlaskAppHTTP(unittest.TestCase):
         response = self.client.get("/unknown")
 
         self.assertEqual(response.status_code, 404)
+
+    def test_forwarded_prefix_applies_to_redirects(self):
+        """ ProxyFix should apply forwarded prefix to redirects. """
+
+        @self.app.app.route("/redirect")
+        def redirect_route():
+            from flask import redirect, url_for
+            return redirect(url_for("root"))
+
+        response = self.client.get(
+            "/redirect",
+            headers={
+                "X-Forwarded-Prefix": "/my-app"
+            },
+            follow_redirects=False
+        )
+
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.headers["Location"], "/my-app/")


### PR DESCRIPTION
# Fix Flask redirects behind Traefik path-prefix routing

## Summary

This PR fixes incorrect Flask redirects when OpenFactory applications are exposed through the Traefik localhost path-prefix gateway in development mode.

Example affected routes:

```text
http://localhost/<app-name>/
```

Previously, Flask applications could generate redirects such as:

```text
http://localhost/cnc/
```

instead of:

```text
http://localhost/<app-name>/cnc/
```

## Root Cause

OpenFactory development deployments use Traefik `StripPrefix` middleware for localhost path-based routing.

Traefik forwards the original external mount path through:

```text
X-Forwarded-Prefix
```

However, Werkzeug/Flask does not trust forwarded proxy headers by default, meaning `SCRIPT_NAME` was not reconstructed correctly during URL generation and redirects.

## Changes

* Enable Werkzeug `ProxyFix` automatically in `OpenFactoryFlaskApp`
* Trust:

  * `X-Forwarded-Prefix`
  * `X-Forwarded-Host`
  * `X-Forwarded-Proto`
* Add tests validating:

  * ProxyFix activation
  * ProxyFix configuration
  * correct redirect behavior with forwarded prefixes

## Result

Flask applications now correctly support both:

```text
http://localhost/<app-name>/
```

and:

```text
http://<app-name>.openfactory.local/
```

without requiring application-specific configuration.
