### PR TITLE
242 fix the generated standard traefik label for routing during the deployment of an openfactory app

### DIFF
--- a/openfactory/openfactory_manager.py
+++ b/openfactory/openfactory_manager.py
@@ -141,7 +141,8 @@ class OpenFactoryManager(OpenFactory):
         # build rule
         rule = f"Host(`{routing.canonical_hostname}`)"
         if routing.alias_hostname:
-            rule += f" || Host(`{routing.alias_hostname}`)"
+            if routing.alias_hostname != routing.canonical_hostname:
+                rule += f" || Host(`{routing.alias_hostname}`)"
 
         labels = {
             "traefik.enable": "true",

--- a/openfactory/schemas/apps.py
+++ b/openfactory/schemas/apps.py
@@ -185,12 +185,11 @@ class Routing(BaseModel):
     canonical_hostname: Optional[str] = None
     alias_hostname: Optional[str] = None
 
-    def build_hostnames(self, app_name: str, app_uuid: str, base_domain: str) -> None:
+    def build_hostnames(self, app_uuid: str, base_domain: str) -> None:
         """
         Generate canonical and optional alias hostnames for the application.
 
-        The canonical hostname is always generated and guarantees uniqueness by
-        combining the normalized application name with a short UUID suffix.
+        The canonical hostname is always generated using the App UUID.
 
         The alias hostname is optional and derived from the user-provided hostname
         field if present.
@@ -201,25 +200,20 @@ class Routing(BaseModel):
         - maximum label length enforced (63 characters)
 
         Args:
-            app_name (str): Name of the application (key in config).
             app_uuid (str): Unique identifier of the application.
             base_domain (str): Base domain used for hostname generation.
 
         Raises:
             RoutingError: If generated hostname labels exceed DNS limits.
         """
-        short_uuid = normalize_name(app_uuid)[:4]
-        norm_name = normalize_name(app_name)
-
-        suffix = f"-{short_uuid}"
-        label = f"{norm_name}{suffix}"
+        label = normalize_name(app_uuid)
 
         # enforce DNS label length
         MAX_LABEL = 63
         if len(label) > MAX_LABEL:
             raise RoutingError(
                 f"Canonical hostname label too long: '{label}' ({len(label)} > {MAX_LABEL}). "
-                f"Shorten app name '{app_name}'."
+                f"Shorten app UUID '{app_uuid}'."
             )
 
         self.canonical_hostname = f"{label}.{base_domain}"
@@ -376,7 +370,6 @@ def get_apps_from_config_file(apps_yaml_config_file: str, uns_schema: UNSSchema)
 
         if app.routing and app.routing.expose:
             app.routing.build_hostnames(
-                app_name=app_name,
                 app_uuid=app.uuid,
                 base_domain=Config.OPENFACTORY_BASE_DOMAIN,
             )

--- a/tests/openfactory/schemas/test_apps.py
+++ b/tests/openfactory/schemas/test_apps.py
@@ -571,7 +571,7 @@ class TestOpenFactoryAppsConfig(unittest.TestCase):
 
         self.assertEqual(
             routing.canonical_hostname,
-            "my-app-abcd.example.com"
+            "abcd1234.example.com"
         )
         self.assertEqual(
             routing.alias_hostname,
@@ -606,8 +606,8 @@ class TestOpenFactoryAppsConfig(unittest.TestCase):
 
         config_data = {
             "apps": {
-                long_name: {
-                    "uuid": "ABCD1234",
+                "test_app": {
+                    "uuid": long_name,
                     "image": "demo",
                     "routing": {
                         "expose": True,
@@ -620,9 +620,8 @@ class TestOpenFactoryAppsConfig(unittest.TestCase):
         config = OpenFactoryAppsConfig(**config_data)
 
         with self.assertRaises(RoutingError):
-            config.apps[long_name].routing.build_hostnames(
-                app_name=long_name,
-                app_uuid="ABCD1234",
+            config.apps["test_app"].routing.build_hostnames(
+                app_uuid=long_name,
                 base_domain="example.com"
             )
 
@@ -646,7 +645,6 @@ class TestOpenFactoryAppsConfig(unittest.TestCase):
 
         with self.assertRaises(RoutingError):
             config.apps["demo1"].routing.build_hostnames(
-                app_name="demo1",
                 app_uuid="ABCD1234",
                 base_domain="example.com"
             )

--- a/tests/openfactory/test_openfactorymanager.py
+++ b/tests/openfactory/test_openfactorymanager.py
@@ -163,15 +163,14 @@ class TestOpenFactoryManager(unittest.TestCase):
         )
 
         labels = self.manager._build_traefik_labels(app)
-
         expected_rule = (
             "Host(`app123.example.com`) || Host(`dashboard.example.com`)"
         )
+        rule = labels["traefik.http.routers.ofa-app123.rule"]
+        self.assertEqual(rule, expected_rule)
 
-        self.assertEqual(
-            labels["traefik.http.routers.ofa-app123.rule"],
-            expected_rule
-        )
+        # ensure no duplicate host rules are generated
+        self.assertEqual(rule.count("Host("), 2)
 
     def test_build_traefik_labels_uuid_normalization(self):
         """ UUID should be normalized in router/service name """
@@ -192,6 +191,27 @@ class TestOpenFactoryManager(unittest.TestCase):
 
         self.assertIn(f"traefik.http.routers.{expected_name}.rule", labels)
         self.assertIn(f"traefik.http.services.{expected_name}.loadbalancer.server.port", labels)
+
+    def test_build_traefik_labels_with_same_alias_as_canonical(self):
+        """ Alias identical to canonical hostname should not duplicate Host rule """
+        app = OpenFactoryAppSchema(
+            uuid="APP123",
+            image="demo",
+            routing={
+                "expose": True,
+                "port": 8000,
+                "canonical_hostname": "app123.example.com",
+                "alias_hostname": "app123.example.com"
+            }
+        )
+
+        labels = self.manager._build_traefik_labels(app)
+        expected_rule = "Host(`app123.example.com`)"
+
+        self.assertEqual(
+            labels["traefik.http.routers.ofa-app123.rule"],
+            expected_rule
+        )
 
     @patch.dict("os.environ", {"OPENFACTORY_ENV": "dev"})
     def test_build_traefik_labels_dev_mode_adds_path_prefix(self):
@@ -639,7 +659,6 @@ class TestOpenFactoryManager(unittest.TestCase):
 
         # simulate enrichment step (normally done in get_apps_from_config_file)
         app.routing.build_hostnames(
-            app_name="My_App",
             app_uuid=app.uuid,
             base_domain="example.com"
         )


### PR DESCRIPTION
Fix the generated Traefik labels during the deployment of an OpenFactory App.

The standard label for routing must be generated based on the application UUID and not the application name which is not guaranteed to be unique in OpenFactory.