### PR TITLE
247 add support for multiple named storage backends in openfactory applications

### DIFF
--- a/openfactory/apps/ofaapp.py
+++ b/openfactory/apps/ofaapp.py
@@ -30,11 +30,11 @@ class OpenFactoryApp(Asset, metaclass=OpenFactoryAppMeta):
         application_version (AssetAttribute): Version from the ``APPLICATION_VERSION`` environment variable or ``"latest"``.
         application_manufacturer (AssetAttribute): Manufacturer from the ``APPLICATION_MANUFACTURER`` environment variable or ``"OpenFactoryIO"``.
         application_license (AssetAttribute): License from the ``APPLICATION_LICENSE`` environment variable or ``"BSD-3-Clause license"``.
-        openfactory_manufacturer (AssetAttribute): OpenFacotory vendor (``"OpenFactoryIO"``)
-        openfactory_license (AssetAttribute): OpenFacotory license (``"Polyform Noncommercial License 1.0.0"``)
+        openfactory_manufacturer (AssetAttribute): OpenFactory vendor (``"OpenFactoryIO"``)
+        openfactory_license (AssetAttribute): OpenFactory license (``"Polyform Noncommercial License 1.0.0"``)
         openfactory_version (AssetAttribute): OpenFactory version
         logger (logging.Logger): Prefixed logger instance configured with the app UUID.
-        storage (Optional [FileBackend]): Storage backend instance created from the ``STORAGE`` environment variable, or ``None`` if not configured.
+        storage (dict[str, FileBackend]): Dictionary mapping storage names to initialized FileBackend instances created from the ``STORAGE`` environment variable. Empty if no storage is configured.
 
     .. admonition:: Usage Example
 
@@ -62,13 +62,24 @@ class OpenFactoryApp(Asset, metaclass=OpenFactoryAppMeta):
                     self.logger.info("Stopping all axis")
 
                 def main_loop(self):
-                    # For actual use case, add here your logic of the app
-                    self.logger.info("I don't do anything useful in this example.")
                     counter = 1
-                    while True:
-                        self.logger.info(f"Counter: {counter}")
-                        counter += 1
-                        time.sleep(2)
+
+                    # Access mounted storage backend
+                    data_storage = self.storage.get("data")
+                    if data_storage is None:
+                        raise RuntimeError("Required storage backend 'data' is not configured")
+
+                    # Open file inside mounted storage
+                    with data_storage.open("counter.txt", "w") as counter_file:
+
+                        while True:
+                            self.logger.info(f"Counter: {counter}")
+
+                            # Persist counter value to storage
+                            counter_file.write(str(counter))
+
+                            counter += 1
+                            time.sleep(2)
 
                 def app_event_loop_stopped(self):
                     # Optional as it is already done by the `KSQLDBClient` class
@@ -111,7 +122,7 @@ class OpenFactoryApp(Asset, metaclass=OpenFactoryAppMeta):
         """
         Initializes the OpenFactory application.
 
-        Sets up the application UUID, storage backend (if configured), standard
+        Sets up the application UUID, configured storage backends, standard
         attributes (version, manufacturer, license), a prefixed logger, and
         termination signal handlers, and automatically registers all methods decorated with
         `@ofa_method <ofa_method.html>`_ decorator.
@@ -127,7 +138,7 @@ class OpenFactoryApp(Asset, metaclass=OpenFactoryAppMeta):
             - If ``bootstrap_servers`` is not explicitly provided, the constructor will attempt to read it from the ``KAFKA_BROKER`` environment variable.
             - If ``asset_router_url`` is not explicitly provided, the constructor will attempt to read it from the ``ASSET_ROUTER_URL`` environment variable.
             - Configures logging with the application UUID as prefix.
-            - Mounts a storage backend if the ``STORAGE`` environment variable is set.
+            - Mounts configured storage backends from the ``STORAGE`` environment variable.
             - Registers signal handlers for ``SIGINT`` and ``SIGTERM``.
 
         .. tip::
@@ -148,12 +159,15 @@ class OpenFactoryApp(Asset, metaclass=OpenFactoryAppMeta):
 
         # attach storage
         storage_env = os.environ.get("STORAGE")
-        self.storage: FileBackend | None = None
+        self.storage: dict[str, FileBackend] = {}
         if storage_env:
-            schema = StorageBackendSchema(storage=json.loads(storage_env))
-            self.storage = schema.storage.create_backend_instance()
-            self.logger.debug(f"Adding storage of type {self.storage.config.type}")
-            self.logger.debug(json.dumps(self.storage.get_mount_spec(), indent=2))
+            storage_configs = json.loads(storage_env)
+            for storage_name, storage_cfg in storage_configs.items():
+                schema = StorageBackendSchema(storage=storage_cfg)
+                backend = schema.storage.create_backend_instance()
+                self.storage[storage_name] = backend
+                self.logger.debug(f"Adding storage '{storage_name}' of type {backend.config.type}")
+                self.logger.debug(json.dumps(backend.get_mount_spec(), indent=2))
 
         # attach decorated methods
         self._subscribe_ofa_methods()

--- a/openfactory/openfactory_manager.py
+++ b/openfactory/openfactory_manager.py
@@ -240,8 +240,11 @@ class OpenFactoryManager(OpenFactory):
 
         # Add STORAGE only if not None
         if application.storage is not None:
-            # Serialize storage config as JSON
-            storage_dict = application.storage.model_dump(exclude_none=True)
+            # Serialize named storage backends
+            storage_dict = {
+                name: storage.model_dump(exclude_none=True)
+                for name, storage in application.storage.items()
+            }
             env.append(f"STORAGE={json.dumps(storage_dict)}")
 
         if application.environment is not None:
@@ -253,16 +256,20 @@ class OpenFactoryManager(OpenFactory):
         if not any(var.startswith("KSQLDB_LOG_LEVEL=") for var in env):
             env.append(f"KSQLDB_LOG_LEVEL={config.KSQLDB_LOG_LEVEL}")
 
-        # add storage
+        # add storage mounts
         mounts = []
         if application.storage:
-            backend_instance = application.storage.create_backend_instance()
-            if isinstance(self.deployment_strategy, SwarmDeploymentStrategy):
-                if not backend_instance.compatible_with_swarm():
-                    raise ValueError(f"{type(backend_instance).__name__} cannot be used with SwarmDeploymentStrategy")
-            mount_spec = backend_instance.get_mount_spec()
-            if mount_spec:
-                mounts.append(mount_spec)
+            for storage_name, storage_cfg in application.storage.items():
+                backend_instance = storage_cfg.create_backend_instance()
+                if isinstance(self.deployment_strategy, SwarmDeploymentStrategy):
+                    if not backend_instance.compatible_with_swarm():
+                        raise ValueError(
+                            f"{type(backend_instance).__name__} "
+                            "cannot be used with SwarmDeploymentStrategy"
+                        )
+                mount_spec = backend_instance.get_mount_spec()
+                if mount_spec:
+                    mounts.append(mount_spec)
 
         try:
             self.deployment_strategy.deploy(

--- a/openfactory/schemas/apps.py
+++ b/openfactory/schemas/apps.py
@@ -10,7 +10,7 @@ ensure application configurations are consistent, valid, and semantically enrich
 Key Components
 --------------
 - :class:`OpenFactoryAppSchema`: Defines a single application including its UUID, Docker image,
-  environment variables, UNS metadata, storage backend, and container networks.
+  environment variables, UNS metadata, named storage backend, and container networks.
 - :class:`OpenFactoryAppsConfig`: Validates a dictionary of application entries and ensures
   correct schema structure.
 - :meth:`get_apps_from_config_file`: Loads, validates, and enriches applications from a
@@ -20,7 +20,7 @@ Features
 --------
 - Supports UNS (Unified Namespace) enrichment through the ``AttachUNSMixin``.
 - Restricts configuration fields with `extra="forbid"` to ensure strict schema conformance.
-- Supports storage backends, including:
+- Supports multiple named storage backends, including:
 
   - ``LocalBackend``: Bind-mount a local host directory into containers (for development).
   - ``NFSBackend``: Mount an NFS share into containers with configurable mount options.
@@ -57,12 +57,17 @@ configuration YAML file, with automatic UNS enrichment.
            - ENV=production
 
           storage:
-            type: nfs
-            server: deskfab.openfactory.com
-            remote_path: /nfs/deskfab
-            mount_point: /mnt
-            mount_options:
-              - ro
+            data:
+              type: nfs
+              server: deskfab.openfactory.com
+              remote_path: /nfs/deskfab
+              mount_point: /mnt
+              mount_options:
+                - ro
+            cache:
+              type: local
+              local_path: ./cache
+              mount_point: /cache
 
           routing:
             expose: true
@@ -260,7 +265,7 @@ class OpenFactoryAppSchema(AttachUNSMixin, BaseModel):
         default=None, description="List of environment variables"
     )
 
-    storage: Optional[StorageBackend] = Field(
+    storage: Optional[Dict[str, StorageBackend]] = Field(
         default=None,
         description="Optional storage backend for the application"
     )
@@ -280,7 +285,27 @@ class OpenFactoryAppSchema(AttachUNSMixin, BaseModel):
         description="Deployment configuration including resources and placement."
     )
 
-    model_config = ConfigDict(extra="forbid")
+    model_config = ConfigDict(
+        extra="forbid",
+        validate_assignment=True
+    )
+
+    @field_validator("storage")
+    @classmethod
+    def validate_storage_names(cls, v):
+        if v:
+            for name in v.keys():
+                if not name.strip():
+                    raise ValueError(
+                        "Storage names must not be empty"
+                    )
+                if not re.match(r"^[a-zA-Z0-9_-]+$", name):
+                    raise ValueError(
+                        f"Invalid storage name '{name}'. "
+                        "Only letters, digits, underscores, and hyphens are allowed."
+                    )
+
+        return v
 
     @field_validator("networks")
     @classmethod

--- a/tests/openfactory/apps/test_openfactoryapp.py
+++ b/tests/openfactory/apps/test_openfactoryapp.py
@@ -95,37 +95,105 @@ class TestOpenFactoryApp(unittest.TestCase):
 
     @patch("openfactory.apps.ofaapp.StorageBackendSchema")
     def test_storage_initialization(self, MockStorageSchema):
-        """ Test that storage JSON is parsed and runtime backend instance is created """
+        """ Test that storage JSON is parsed and runtime backend instances are created """
 
-        # Mock the StorageBackendSchema instance
-        mock_schema_instance = MockStorageSchema.return_value
+        # Mock backend instance
         mock_backend_instance = MagicMock(spec=FileBackend)
         mock_backend_instance.config = MagicMock()
         mock_backend_instance.config.type = "nfs"
+        mock_backend_instance.get_mount_spec.return_value = {}
+
+        # Mock schema instance
+        mock_schema_instance = MagicMock()
         mock_schema_instance.storage.create_backend_instance.return_value = mock_backend_instance
 
-        # Make get_mount_spec return a dict so json.dumps() works in code under test
-        mock_backend_instance.get_mount_spec.return_value = {}
+        # Every StorageBackendSchema(...) returns same mock schema
+        MockStorageSchema.return_value = mock_schema_instance
 
         # Example storage JSON
         storage_json = json.dumps({
-            "type": "nfs",
-            "server": "10.0.5.2",
-            "remote_path": "/nfs/data",
-            "mount_point": "/mnt",
-            "mount_options": ["rw", "noatime"]
+            "data": {
+                "type": "nfs",
+                "server": "10.0.5.2",
+                "remote_path": "/nfs/data",
+                "mount_point": "/mnt",
+                "mount_options": ["rw", "noatime"]
+            }
         })
 
         with patch.dict("os.environ", {"STORAGE": storage_json}):
-            app = OpenFactoryApp(bootstrap_servers='mocked_broker', asset_router_url='mocked_asset_url',
-                                 ksqlClient=self.ksql_mock)
+            app = OpenFactoryApp(
+                bootstrap_servers='mocked_broker',
+                asset_router_url='mocked_asset_url',
+                ksqlClient=self.ksql_mock
+            )
 
-        # Assert StorageBackendSchema was called with parsed JSON
-        MockStorageSchema.assert_called_once_with(storage=json.loads(storage_json))
-        # Assert create_backend_instance() was called
+        # Assert StorageBackendSchema called correctly
+        MockStorageSchema.assert_called_once_with(storage=json.loads(storage_json)["data"])
+
+        # Assert backend instance creation
         mock_schema_instance.storage.create_backend_instance.assert_called_once()
-        # Assert self.storage is set to the backend instance
-        self.assertIs(app.storage, mock_backend_instance)
+
+        # Assert storage dictionary exists
+        self.assertIn("data", app.storage)
+
+        # Assert backend stored correctly
+        self.assertIs(app.storage["data"], mock_backend_instance)
+
+    @patch("openfactory.apps.ofaapp.StorageBackendSchema")
+    def test_multiple_storage_initialization(self, MockStorageSchema):
+        """ Multiple storage backends are initialized correctly """
+
+        # Backend mocks
+        mock_data_backend = MagicMock(spec=FileBackend)
+        mock_data_backend.config = MagicMock()
+        mock_data_backend.config.type = "nfs"
+        mock_data_backend.get_mount_spec.return_value = {}
+
+        mock_cache_backend = MagicMock(spec=FileBackend)
+        mock_cache_backend.config = MagicMock()
+        mock_cache_backend.config.type = "local"
+        mock_cache_backend.get_mount_spec.return_value = {}
+
+        # Schema mocks
+        mock_schema_1 = MagicMock()
+        mock_schema_1.storage.create_backend_instance.return_value = mock_data_backend
+
+        mock_schema_2 = MagicMock()
+        mock_schema_2.storage.create_backend_instance.return_value = mock_cache_backend
+
+        MockStorageSchema.side_effect = [
+            mock_schema_1,
+            mock_schema_2
+        ]
+
+        storage_json = json.dumps({
+            "data": {
+                "type": "nfs",
+                "server": "10.0.5.2",
+                "remote_path": "/nfs/data",
+                "mount_point": "/mnt"
+            },
+            "cache": {
+                "type": "local",
+                "local_path": "/tmp/cache",
+                "mount_point": "/cache"
+            }
+        })
+
+        with patch.dict("os.environ", {"STORAGE": storage_json}):
+
+            app = OpenFactoryApp(
+                bootstrap_servers='mocked_broker',
+                asset_router_url='mocked_asset_url',
+                ksqlClient=self.ksql_mock
+            )
+
+        self.assertIn("data", app.storage)
+        self.assertIn("cache", app.storage)
+
+        self.assertIs(app.storage["data"], mock_data_backend)
+        self.assertIs(app.storage["cache"], mock_cache_backend)
 
     def test_attributes_added(self):
         """ Test if attributes are added correctly to the app """

--- a/tests/openfactory/schemas/test_apps.py
+++ b/tests/openfactory/schemas/test_apps.py
@@ -328,20 +328,25 @@ class TestOpenFactoryAppsConfig(unittest.TestCase):
                     "uuid": "DEMO-APP",
                     "image": "demofact/demo1",
                     "storage": {
-                        "type": "nfs",
-                        "server": "192.168.1.10",
-                        "remote_path": "/exports/data",
-                        "mount_point": "/mnt/data",
-                        "mount_options": ["rw", "vers=4.1", "noatime"]
+                        "data": {
+                            "type": "nfs",
+                            "server": "192.168.1.10",
+                            "remote_path": "/exports/data",
+                            "mount_point": "/mnt/data",
+                            "mount_options": ["rw", "vers=4.1", "noatime"]
+                        }
                     }
                 }
             }
         }
         config = OpenFactoryAppsConfig(**app_config)
         storage = config.apps["demo1"].storage
-        self.assertEqual(storage.type, "nfs")
-        self.assertEqual(storage.server, "192.168.1.10")
-        self.assertEqual(storage.mount_point, "/mnt/data")
+        self.assertIn("data", storage)
+
+        data_storage = storage["data"]
+        self.assertEqual(data_storage.type, "nfs")
+        self.assertEqual(data_storage.server, "192.168.1.10")
+        self.assertEqual(data_storage.mount_point, "/mnt/data")
 
     def test_invalid_storage_type(self):
         """ Test that unknown storage backend type triggers ValidationError with correct message """
@@ -352,8 +357,10 @@ class TestOpenFactoryAppsConfig(unittest.TestCase):
                     "uuid": "DEMO-APP",
                     "image": "demofact/demo1",
                     "storage": {
-                        "type": "unknown",
-                        "foo": "bar"
+                        "data": {
+                            "type": "unknown",
+                            "foo": "bar"
+                        }
                     }
                 }
             }
@@ -367,10 +374,72 @@ class TestOpenFactoryAppsConfig(unittest.TestCase):
         # There should be a union_tag_invalid error for 'storage'
         storage_error = [
             e for e in errors
-            if e['loc'][-1] == 'storage' and e['type'] == 'union_tag_invalid'
+            if 'storage' in e['loc']
+            and e['type'] == 'union_tag_invalid'
         ]
 
         self.assertTrue(storage_error, "ValidationError should include 'union_tag_invalid' for 'storage' field")
+
+    def test_invalid_storage_name(self):
+        """ Invalid storage names should raise ValidationError """
+
+        invalid_config = {
+            "apps": {
+                "demo1": {
+                    "uuid": "DEMO-APP",
+                    "image": "demofact/demo1",
+                    "storage": {
+                        "invalid name!": {
+                            "type": "nfs",
+                            "server": "192.168.1.10",
+                            "remote_path": "/exports/data",
+                            "mount_point": "/mnt/data"
+                        }
+                    }
+                }
+            }
+        }
+
+        with self.assertRaises(ValidationError) as cm:
+            OpenFactoryAppsConfig(**invalid_config)
+
+        self.assertIn("Invalid storage name", str(cm.exception))
+
+    def test_multiple_storage_backends(self):
+        """ Multiple storage backends are parsed correctly """
+
+        config_data = {
+            "apps": {
+                "demo1": {
+                    "uuid": "DEMO-APP",
+                    "image": "demofact/demo1",
+                    "storage": {
+                        "data": {
+                            "type": "nfs",
+                            "server": "192.168.1.10",
+                            "remote_path": "/exports/data",
+                            "mount_point": "/mnt/data"
+                        },
+                        "cache": {
+                            "type": "nfs",
+                            "server": "192.168.1.10",
+                            "remote_path": "/exports/cache",
+                            "mount_point": "/mnt/cache"
+                        }
+                    }
+                }
+            }
+        }
+
+        config = OpenFactoryAppsConfig(**config_data)
+
+        storage = config.apps["demo1"].storage
+
+        self.assertIn("data", storage)
+        self.assertIn("cache", storage)
+
+        self.assertEqual(storage["data"].type, "nfs")
+        self.assertEqual(storage["cache"].type, "nfs")
 
     def test_optional_networks(self):
         """ networks field is optional """

--- a/tests/openfactory/test_openfactorymanager.py
+++ b/tests/openfactory/test_openfactorymanager.py
@@ -560,7 +560,7 @@ class TestOpenFactoryManager(unittest.TestCase):
     @patch("openfactory.openfactory_manager.user_notify")
     @patch("openfactory.openfactory_manager.register_asset")
     def test_deploy_openfactory_application_includes_storage_env(self, mock_register_asset, mock_user_notify):
-        """ Test that deploy_openfactory_application includes STORAGE in env when storage is provided """
+        """ STORAGE environment variable should contain serialized storage backends """
 
         nfs_config = NFSBackendConfig(
             type="nfs",
@@ -575,72 +575,44 @@ class TestOpenFactoryManager(unittest.TestCase):
             image="app_image",
             environment=["FOO=bar"],
             uns=None,
-            storage=nfs_config,
+            storage={"data": nfs_config}
         )
 
-        # Patch backend class so we don't try to mount anything
         with patch("openfactory.filelayer.nfs_backend.NFSBackend") as MockBackend:
             backend_instance = MockBackend.return_value
-            backend_instance.get_mount_spec.return_value = None
+            backend_instance.get_mount_spec.return_value = {
+                "source": "nfs.example.com:/data/share",
+                "target": "/mnt/data",
+                "type": "volume"
+            }
 
             self.manager.deploy_openfactory_application(app)
 
-        # Extract env from the call to deploy
+        # Extract env passed to deploy()
         deploy_call = self.manager.deployment_strategy.deploy.call_args
         env_list = deploy_call.kwargs["env"]
 
-        # STORAGE env var should be present and contain serialized config
-        storage_env = next((e for e in env_list if e.startswith("STORAGE=")), None)
-        self.assertIsNotNone(storage_env, "Expected STORAGE env var to be included")
+        # STORAGE env variable exists
+        storage_env = next(
+            (e for e in env_list if e.startswith("STORAGE=")),
+            None
+        )
+
+        self.assertIsNotNone(storage_env, "Expected STORAGE environment variable")
+
+        # Serialized storage dict content
+        self.assertIn('"data"', storage_env)
         self.assertIn('"type": "nfs"', storage_env)
         self.assertIn('"server": "nfs.example.com"', storage_env)
         self.assertIn('"/mnt/data"', storage_env)
 
-        # Other env vars should still be present
+        # Normal env vars still present
         self.assertIn("APP_UUID=APP_WITH_STORAGE", env_list)
         self.assertIn("FOO=bar", env_list)
 
         mock_user_notify.success.assert_called_once_with(
             "Application APP_WITH_STORAGE deployed successfully"
         )
-
-    @patch("openfactory.openfactory_manager.user_notify")
-    @patch("openfactory.openfactory_manager.register_asset")
-    def test_deploy_with_nfs_storage_calls_backend(self, mock_register_asset, mock_user_notify):
-        """ Test that deploying an app with NFS storage calls the backend's get_mount_spec """
-
-        nfs_config = NFSBackendConfig(
-            type="nfs",
-            server="nfs.example.com",
-            remote_path="/data/share",
-            mount_point="/mnt/data",
-            mount_options=["rw"]
-        )
-
-        app = OpenFactoryAppSchema(
-            uuid="APP123",
-            image="app_image",
-            environment=None,
-            uns=None,
-            storage=nfs_config
-        )
-
-        with patch("openfactory.filelayer.nfs_backend.NFSBackend") as MockBackend:
-            backend_instance = MockBackend.return_value
-            mount_spec = {"source": "nfs.example.com:/data/share", "target": "/mnt/data", "type": "volume"}
-            backend_instance.get_mount_spec.return_value = mount_spec
-
-            self.manager.deploy_openfactory_application(app)
-
-            # Backend instantiation and get_mount_spec called
-            MockBackend.assert_called_once_with(nfs_config)
-            backend_instance.get_mount_spec.assert_called_once()
-
-            # Deployment strategy received the mount spec
-            self.manager.deployment_strategy.deploy.assert_called_once()
-            deploy_kwargs = self.manager.deployment_strategy.deploy.call_args.kwargs
-            self.assertIn("mounts", deploy_kwargs)
-            self.assertIn(mount_spec, deploy_kwargs["mounts"])
 
     @patch("openfactory.openfactory_manager.register_asset")
     @patch("openfactory.openfactory_manager.user_notify")
@@ -773,9 +745,13 @@ class TestOpenFactoryManager(unittest.TestCase):
         app = MagicMock()
         app.uuid = "APP1"
         app.environment = []
-        app.storage = LocalBackendConfig(type="local",
-                                         local_path="/tmp/host",
-                                         mount_point="/mnt/data")
+        app.storage = {
+            "data": LocalBackendConfig(
+                type="local",
+                local_path="/tmp/host",
+                mount_point="/mnt/data"
+            )
+        }
 
         # Assign a SwarmDeploymentStrategy instance to the manager
         self.manager.deployment_strategy = SwarmDeploymentStrategy()
@@ -785,6 +761,40 @@ class TestOpenFactoryManager(unittest.TestCase):
             self.manager.deploy_openfactory_application(app)
 
         self.assertIn("LocalBackend cannot be used with SwarmDeploymentStrategy", str(cm.exception))
+
+    @patch("os.path.exists", return_value=True)
+    @patch("os.path.isdir", return_value=True)
+    def test_mixed_storage_backends_fail_with_swarm(self, mock_isdir, mock_exists):
+        """ Deployment should fail if any configured storage backend is incompatible with SwarmDeploymentStrategy. """
+
+        app = MagicMock()
+        app.uuid = "APP1"
+        app.environment = []
+        app.storage = {
+            "data": NFSBackendConfig(
+                type="nfs",
+                server="nfs.example.com",
+                remote_path="/exports/data",
+                mount_point="/data"
+            ),
+            "cache": LocalBackendConfig(
+                type="local",
+                local_path="/tmp/cache",
+                mount_point="/cache"
+            )
+        }
+
+        # Use Swarm deployment strategy
+        self.manager.deployment_strategy = SwarmDeploymentStrategy()
+
+        # Deployment must fail because LocalBackend is incompatible
+        with self.assertRaises(ValueError) as cm:
+            self.manager.deploy_openfactory_application(app)
+
+        self.assertIn(
+            "LocalBackend cannot be used with SwarmDeploymentStrategy",
+            str(cm.exception)
+        )
 
     @patch('openfactory.openfactory_manager.get_apps_from_config_file')
     @patch('openfactory.openfactory_manager.user_notify')


### PR DESCRIPTION
## Add support for multiple named storage backends in OpenFactory applications

## Summary

This PR extends OpenFactory application storage configuration to support multiple named storage backends instead of a single backend definition.

Applications can now define several logical storage mounts such as `data`, `cache`, `models`, or `logs`, each backed by its own storage backend configuration.

Example:

```yaml id="jlwm16"
apps:
  scheduler:
    uuid: "app-scheduler"
    image: ghcr.io/openfactoryio/scheduler:v1.0.0

    storage:
      data:
        type: nfs
        server: storage.example.com
        remote_path: /exports/data
        mount_point: /data

      cache:
        type: local
        local_path: /tmp/cache
        mount_point: /cache
```

---

## Motivation

The previous storage model only supported a single backend per application:

```yaml id="7jlwm5"
storage:
  type: nfs
  ...
```

This became limiting for real-world deployments where applications often require:

* persistent application data
* temporary cache storage
* log storage
* model repositories
* shared datasets
* scratch or workspace directories

This PR introduces a more flexible and semantically clear storage architecture.

---

## Main Changes

### Schema Changes

`OpenFactoryAppSchema.storage` changed from:

```python id="3jlwm9"
Optional[StorageBackend]
```

to:

```python id="8jlwm6"
Optional[Dict[str, StorageBackend]]
```

Storage entries are now indexed by logical names.

Example runtime access:

```python id="5jlwm3"
self.storage["data"]
```

---

### Runtime Changes

`OpenFactoryApp` now exposes:

```python id="2jlwm7"
self.storage: dict[str, FileBackend]
```

instead of a single backend instance.

Storage backends are initialized dynamically from the serialized `STORAGE` environment variable.

Applications can now interact directly with named storage backends:

```python id="4jlwm3"
with self.storage["data"].open("counter.txt", "w") as f:
    f.write("hello")
```

---

### Deployment Changes

Deployment logic now:

* serializes all configured storage backends into `STORAGE`
* creates mounts for all configured backends
* performs Swarm compatibility checks per backend

Example serialized runtime environment:

```json id="5jlwm4"
{
  "data": {
    "type": "nfs",
    ...
  },
  "cache": {
    "type": "local",
    ...
  }
}
```

---

## Validation Rules

Storage names:

* must not be empty
* may contain:

  * letters
  * digits
  * `_`
  * `-`

Invalid storage names raise `ValidationError`.

---

## Swarm Compatibility

Swarm compatibility is now evaluated individually for each configured backend.

Applications mixing compatible and incompatible backends correctly fail deployment under `SwarmDeploymentStrategy`.

Example:

```yaml id="3jlwm0"
storage:
  data:
    type: nfs

  cache:
    type: local
```

This deployment fails under Swarm because `LocalBackend` is incompatible.

---

## Documentation Updates

Updated:

* schema documentation
* runtime API documentation
* application examples
* storage runtime examples

Added explicit example demonstrating runtime file access through named storage backends.

---

## Tests

Refactored existing tests and added coverage for:

* multiple storage backend parsing
* runtime storage initialization
* deployment environment serialization
* mount generation for multiple backends
* Swarm compatibility validation per backend
* mixed compatible/incompatible backend scenarios
* storage name validation

All existing storage-related tests were updated to reflect the new architecture.
