### PR TITLE
249 configure application root automatically in openfactoryflaskapp

### DIFF
--- a/openfactory/apps/ofa_flask_app.py
+++ b/openfactory/apps/ofa_flask_app.py
@@ -246,6 +246,11 @@ class OpenFactoryFlaskApp(OpenFactoryApp):
             x_proto=1,
         )
 
+        # set root path if deployed on OpenFactory cluster
+        root_path = os.environ.get("OPENFACTORY_ROOT_PATH")
+        if (root_path and self.app.config.get("APPLICATION_ROOT") == "/"):
+            self.app.config["APPLICATION_ROOT"] = root_path
+
         # expose OpenFactory app inside Flask
         self.app.ofa_app = self
 

--- a/tests/openfactory/apps/test_openfactory_flask_app.py
+++ b/tests/openfactory/apps/test_openfactory_flask_app.py
@@ -44,6 +44,63 @@ class TestOpenFactoryFlaskApp(unittest.TestCase):
 
         self.assertIsInstance(app.app, Flask)
 
+    def test_application_root_not_set_when_env_missing(self):
+        """ Should not inject APPLICATION_ROOT if env var is absent """
+
+        with patch.dict("os.environ", {}, clear=True):
+
+            app = OpenFactoryFlaskApp(
+                ksqlClient=self.ksql_mock,
+                bootstrap_servers="mock",
+                asset_router_url="mock"
+            )
+
+            self.assertEqual(app.app.config["APPLICATION_ROOT"], "/")
+
+    def test_application_root_loaded_from_env(self):
+        """ Should configure APPLICATION_ROOT from env var """
+
+        with patch.dict(
+            "os.environ",
+            {"OPENFACTORY_ROOT_PATH": "/my-app"},
+            clear=True
+        ):
+
+            app = OpenFactoryFlaskApp(
+                ksqlClient=self.ksql_mock,
+                bootstrap_servers="mock",
+                asset_router_url="mock"
+            )
+
+            self.assertEqual(
+                app.app.config["APPLICATION_ROOT"],
+                "/my-app"
+            )
+
+    def test_application_root_user_override_preserved(self):
+        """ User-defined APPLICATION_ROOT should not be overwritten """
+
+        class App(OpenFactoryFlaskApp):
+
+            def create_flask_app(self):
+                app = Flask(__name__)
+                app.config["APPLICATION_ROOT"] = "/user-defined"
+                return app
+
+        with patch.dict(
+            "os.environ",
+            {"OPENFACTORY_ROOT_PATH": "/framework-defined"},
+            clear=True
+        ):
+
+            app = App(
+                ksqlClient=self.ksql_mock,
+                bootstrap_servers="mock",
+                asset_router_url="mock"
+            )
+
+            self.assertEqual(app.app.config["APPLICATION_ROOT"], "/user-defined")
+
     def test_create_flask_app_called(self):
         """ Test initialization calls create_flask_app """
 


### PR DESCRIPTION
### Automatically configure Flask `APPLICATION_ROOT` from OpenFactory routing in `OpenFactoryFlaskApp`

Configure Flask `APPLICATION_ROOT` automatically in `OpenFactoryFlaskApp` when `OPENFACTORY_ROOT_PATH` is defined.

This ensures correct Flask behavior when applications are deployed behind the OpenFactory Traefik routing gateway using a path prefix.

Without this configuration, Flask applications can exhibit inconsistent behavior, including:

* incorrect URL generation
* broken redirects
* invalid session cookie paths
* session persistence issues across redirects
* Blueprint routing inconsistencies under path prefixes

Behavior:

* If `OPENFACTORY_ROOT_PATH` is not defined:

  * preserve default Flask behavior
  * do not modify `APPLICATION_ROOT`

* If `OPENFACTORY_ROOT_PATH` is defined:

  * automatically configure `APPLICATION_ROOT`
  * preserve explicit user-defined values from `create_flask_app()`
