### PR TITLE
Fix Kafka tombstones with ksqlDB by enabling Java-compatible partitioning

### DIFF
--- a/openfactory/kafka/asset_producer.py
+++ b/openfactory/kafka/asset_producer.py
@@ -27,7 +27,13 @@ class AssetProducer(Producer):
             ksqlClient (KSQLDBClient): Client to retrieve Kafka topic info, typically a wrapper over ksqlDB.
             bootstrap_servers (str): Kafka bootstrap server address, defaults to value from config.
         """
-        super().__init__({'bootstrap.servers': bootstrap_servers})
+
+        # Use Java-compatible murmur2_random partitioning (Kafka Streams / ksqlDB interoperability)
+        # Required so identical keys map to identical partitions across Python and Java producers.
+        super().__init__({
+            'bootstrap.servers': bootstrap_servers,
+            'partitioner': 'murmur2_random'
+            })
         self.ksql = ksqlClient
         self.topic = self.ksql.get_kafka_topic('ASSETS_STREAM')
 

--- a/openfactory/kafka/asset_producer.py
+++ b/openfactory/kafka/asset_producer.py
@@ -30,10 +30,12 @@ class AssetProducer(Producer):
 
         # Use Java-compatible murmur2_random partitioning (Kafka Streams / ksqlDB interoperability)
         # Required so identical keys map to identical partitions across Python and Java producers.
-        super().__init__({
+        self.producer_config = {
             'bootstrap.servers': bootstrap_servers,
             'partitioner': 'murmur2_random'
-            })
+        }
+
+        super().__init__(self.producer_config)
         self.ksql = ksqlClient
         self.topic = self.ksql.get_kafka_topic('ASSETS_STREAM')
 

--- a/tests/openfactory/kafka/test_assetproducer.py
+++ b/tests/openfactory/kafka/test_assetproducer.py
@@ -1,6 +1,6 @@
 import unittest
 import json
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 from openfactory.kafka import AssetProducer
 
 
@@ -33,8 +33,23 @@ class TestAssetProducer(unittest.TestCase):
         self.assertEqual(producer.ksql, mock_ksql)
         self.assertEqual(producer.topic, expected_topic)
 
+    def test_asset_producer_sets_bootstrap_servers(self):
+        """ Ensure producer stores configured bootstrap servers. """
+
+        mock_ksql = MagicMock()
+        mock_ksql.get_kafka_topic.return_value = "ASSETS_STREAM"
+        producer = AssetProducer(
+            mock_ksql,
+            bootstrap_servers="test-broker:9092"
+        )
+
+        self.assertEqual(
+            producer.producer_config['bootstrap.servers'],
+            'test-broker:9092'
+        )
+
     def test_asset_producer_uses_java_compatible_partitioner(self):
-        """Ensure producer uses Java-compatible partitioning."""
+        """ Ensure producer uses Java-compatible partitioning. """
 
         mock_ksql = MagicMock()
         mock_ksql.get_kafka_topic.return_value = "ASSETS_STREAM"

--- a/tests/openfactory/kafka/test_assetproducer.py
+++ b/tests/openfactory/kafka/test_assetproducer.py
@@ -1,6 +1,6 @@
 import unittest
 import json
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 from openfactory.kafka import AssetProducer
 
 
@@ -32,6 +32,22 @@ class TestAssetProducer(unittest.TestCase):
 
         self.assertEqual(producer.ksql, mock_ksql)
         self.assertEqual(producer.topic, expected_topic)
+
+    def test_asset_producer_uses_java_compatible_partitioner(self):
+        """Ensure producer uses Java-compatible partitioning."""
+
+        mock_ksql = MagicMock()
+        mock_ksql.get_kafka_topic.return_value = "ASSETS_STREAM"
+
+        producer = AssetProducer(
+            mock_ksql,
+            bootstrap_servers="test-broker:9092"
+        )
+
+        self.assertEqual(
+            producer.producer_config['partitioner'],
+            'murmur2_random'
+        )
 
     def test_send_asset_attribute(self):
         """ Test send_asset_attribute """


### PR DESCRIPTION
# Fix Kafka tombstones with ksqlDB by enabling Java-compatible partitioning

## Summary

This PR fixes an interoperability issue between Python Kafka producers (`confluent_kafka` / `librdkafka`) and ksqlDB/Kafka Streams producers when using compacted topics with multiple partitions.

Without explicit Java-compatible partitioning:

* records and tombstones for the same key could land in different Kafka partitions
* tombstones would therefore fail to delete rows from ksqlDB `SOURCE TABLE`s
* behavior appeared correct with 1 partition but failed with multiple partitions

The root cause was that:

* ksqlDB/Kafka Streams use Java producer Murmur2 partitioning
* `librdkafka` default partitioning is not Java-compatible

This PR explicitly configures Python producers to use Java-compatible partitioning via:

```python id="7tr8rw"
'partitioner': 'murmur2_random'
```

---

# Changes

## AssetProducer

Added Java-compatible partitioning configuration:

```python id="6b40x8"
super().__init__({
    'bootstrap.servers': bootstrap_servers,
    'partitioner': 'murmur2_random'
})
```

Added explanatory comment documenting interoperability requirements with:

* ksqlDB
* Kafka Streams
* compacted topics
* tombstones

---

# Tests

Added regression tests verifying:

* configured bootstrap servers
* Java-compatible partitioner configuration

This protects against accidental removal of the required partitioner setting in the future.

---

# Result

After this change:

* tombstones produced from Python land in the same partitions as ksqlDB-produced records
* deletions from compacted topics work correctly
* ksqlDB `SOURCE TABLE`s update as expected across multiple partitions
* producer behavior becomes deterministic across Python and Java Kafka clients
