### PR TITLE
Fix inherited @ofa_method registration across class hierarchy

### DIFF
--- a/openfactory/apps/ofaapp.py
+++ b/openfactory/apps/ofaapp.py
@@ -191,40 +191,41 @@ class OpenFactoryApp(Asset, metaclass=OpenFactoryAppMeta):
 
     def _subscribe_ofa_methods(self):
         """ Scan decorated methods and subscribe to their CMD attributes. """
-        # Iterate over class attributes
-        for attr_name, attr in type(self).__dict__.items():
-            if hasattr(attr, "_ofa_method_metadata") and inspect.isfunction(attr):
-                # attr is the original function (safe to access __name__)
-                method = getattr(self, attr_name)       # bind to self for execution
-                cmd_attribute = f"{attr.__name__}_CMD"  # use unbound function's __name__
+        # Scan decorated methods across the full class inheritance chain (MRO)
+        for cls in reversed(type(self).mro()):
+            for attr_name, attr in cls.__dict__.items():
+                if hasattr(attr, "_ofa_method_metadata") and inspect.isfunction(attr):
+                    # attr is the original function (safe to access __name__)
+                    method = getattr(self, attr_name)       # bind to self for execution
+                    cmd_attribute = f"{attr.__name__}_CMD"  # use unbound function's __name__
 
-                # Build callback closure
-                def make_callback(meth):
-                    def on_cmd(msg_key, msg_value):
-                        try:
-                            envelope = CommandEnvelope.model_validate_json(msg_value['VALUE'])
-                            # execute method with envelope arguments
-                            self._execute_ofa_method(meth, envelope)
-                        except Exception as e:
-                            self.logger.error(
-                                f"[{self.asset_uuid}] Failed to execute {meth.__name__}: {type(e).__name__}: {e}",
-                                exc_info=True
-                            )
-                    return on_cmd
+                    # Build callback closure
+                    def make_callback(meth):
+                        def on_cmd(msg_key, msg_value):
+                            try:
+                                envelope = CommandEnvelope.model_validate_json(msg_value['VALUE'])
+                                # execute method with envelope arguments
+                                self._execute_ofa_method(meth, envelope)
+                            except Exception as e:
+                                self.logger.error(
+                                    f"[{self.asset_uuid}] Failed to execute {meth.__name__}: {type(e).__name__}: {e}",
+                                    exc_info=True
+                                )
+                        return on_cmd
 
-                # Register command as asset attributes
-                self._register_ofa_method(method)
-                self.add_attribute(
-                    asset_attribute=AssetAttribute(
-                        id=cmd_attribute,
-                        value="",
-                        type='OpenFactory',
-                        tag='Method.Command'
+                    # Register command as asset attributes
+                    self._register_ofa_method(method)
+                    self.add_attribute(
+                        asset_attribute=AssetAttribute(
+                            id=cmd_attribute,
+                            value="",
+                            type='OpenFactory',
+                            tag='Method.Command'
+                        )
                     )
-                )
 
-                if not self._test_mode:
-                    self.subscribe_to_attribute(cmd_attribute, make_callback(method))
+                    if not self._test_mode:
+                        self.subscribe_to_attribute(cmd_attribute, make_callback(method))
 
     def _register_ofa_method(self, method) -> None:
         """

--- a/tests/openfactory/apps/test_ofa_method.py
+++ b/tests/openfactory/apps/test_ofa_method.py
@@ -240,3 +240,39 @@ class TestOFAMethodDecorator(unittest.TestCase):
 
         metadata = Dummy.move._ofa_method_metadata
         self.assertEqual(metadata["description"], "Some spaces to remove.")
+
+    def test_inherited_ofa_methods_are_registered(self):
+        """ Decorated methods inherited from parent classes should also be registered. """
+
+        from openfactory.apps import OpenFactoryApp
+        from openfactory.kafka import KSQLDBClient
+
+        class BaseApp(OpenFactoryApp):
+
+            @ofa_method()
+            def parent_method(self):
+                pass
+
+        class ChildApp(BaseApp):
+
+            @ofa_method()
+            def child_method(self):
+                pass
+
+        class GrandChildApp(ChildApp):
+
+            @ofa_method()
+            def grandchild_method(self):
+                pass
+
+        app = GrandChildApp(
+            ksqlClient=KSQLDBClient("http://localhost:8088"),
+            bootstrap_servers="localhost:9092",
+            test_mode=True
+        )
+
+        attribute_ids = app.attributes()
+
+        self.assertIn("parent_method", attribute_ids)
+        self.assertIn("child_method", attribute_ids)
+        self.assertIn("grandchild_method", attribute_ids)


### PR DESCRIPTION
### Summary

Fixes a bug where methods decorated with `@ofa_method` were not registered when inherited from parent classes.

Previously, `_subscribe_ofa_methods()` only scanned:

```python id="r3m9kx"
type(self).__dict__
```

which excludes inherited methods.

This caused:

* inherited OpenFactory methods to not be registered
* missing `<method>_CMD` attributes
* missing command subscriptions
* inability to remotely invoke inherited methods

---

### Fix

Method discovery now traverses the full class inheritance hierarchy using the MRO:

```python id="g7w2pv"
for cls in reversed(type(self).mro()):
    for attr_name, attr in cls.__dict__.items():
```

This:

* correctly discovers inherited decorated methods
* supports arbitrarily deep inheritance chains
* preserves normal Python override semantics

---

### Added Regression Test

Added regression test:

```python id="x2q8me"
test_inherited_ofa_methods_are_registered
```

The test validates registration across:

* parent
* child
* grandchild

inheritance chains.

---

### Example

Previously:

```python id="n6m3ja"
class BaseApp(OpenFactoryApp):

    @ofa_method()
    def parent_method(self):
        pass


class ChildApp(BaseApp):

    @ofa_method()
    def child_method(self):
        pass
```

Only `child_method` was registered.

After this fix:

* `parent_method`
* `parent_method_CMD`
* `child_method`
* `child_method_CMD`

are all correctly registered.
