### PR TITLE
Add SHDR connector configuration schemas

### DIFF
--- a/docs/api/schemas/connectors.rst
+++ b/docs/api/schemas/connectors.rst
@@ -23,3 +23,4 @@ Submodules
    connectors.types
    connectors.mtconnect
    connectors.opcua
+   connectors.shdr

--- a/docs/api/schemas/connectors.shdr.rst
+++ b/docs/api/schemas/connectors.shdr.rst
@@ -1,0 +1,7 @@
+SHDR Connector Schemas
+======================
+
+.. automodule:: openfactory.schemas.connectors.shdr
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -39,6 +39,7 @@ nitpick_ignore = [
     ('py:class', 'asyncua.Client'),
     ('py:class', 'cimpl.Producer'),
     ('py:class', 'pydantic.main.BaseModel'),
+    ("py:class", "pydantic.networks.IPvAnyAddress"),
     ('py:class', 'pydantic.root_model.RootModel[Dict[str, Node]]'),
     ('py:class', 'pydantic.root_model.RootModel[Dict[str, Union[Volume, NoneType]]]'),
     ('py:class', 'pydantic.root_model.RootModel[Dict[str, Optional[Volume]]]'),

--- a/openfactory/schemas/connectors/shdr.py
+++ b/openfactory/schemas/connectors/shdr.py
@@ -1,0 +1,104 @@
+"""
+SHDR Connector Schemas
+
+This module provides Pydantic models to define and validate configuration
+schemas for SHDR devices within OpenFactory.
+
+Key Models:
+-----------
+- :class:`SHDRDataPointSchema`:
+
+  Configuration for a single SHDR data point. Contains a ``tag`` used by
+  OpenFactory to label incoming SHDR data and a ``type`` defining the type
+  of the data point (``Samples`` or ``Events``).
+
+- :class:`SHDRConnectorSchema`:
+
+  Wrapper schema that encapsulates the SHDR server configuration along
+  with all configured SHDR data points.
+
+Validation Features:
+--------------------
+- Validates ``host`` as a valid IPv4 or IPv6 address.
+- Validates ``port`` range (1-65535).
+- Restricts SHDR data point ``type`` to ``Samples`` or ``Events``.
+- Forbids unknown fields to ensure strict schema conformance.
+- Supports immutable validated configuration models.
+
+YAML Example:
+-------------
+.. code-block:: yaml
+
+    type: shdr
+
+    host: 192.168.1.10
+    port: 7878
+
+    data:
+        temp:
+            tag: Temperature
+            type: Samples
+
+        humi:
+            tag: Humidity
+            type: Events
+
+.. seealso::
+
+   The runtime class of the SHDRConnectorSchema schema is
+   :class:`openfactory.connectors.shdr.shdr_connector.SHDRConnector`.
+"""
+
+from typing import Literal, Dict
+from pydantic import BaseModel, ConfigDict, Field, IPvAnyAddress
+
+
+class SHDRDataPointSchema(BaseModel):
+    """ Configuration for a single SHDR data point. """
+
+    tag: str = Field(
+        ...,
+        description="SHDR tag name."
+    )
+
+    type: Literal["Samples", "Events"] = Field(
+        ...,
+        description="SHDR stream type."
+    )
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+
+class SHDRConnectorSchema(BaseModel):
+    """
+    SHDR Connector schema wrapping the server configuration.
+
+    The ``type`` field is a discriminator for Pydantic to select this schema.
+
+    .. seealso::
+
+       The runtime class of the :class:`SHDRConnectorSchema` schema is :class:`openfactory.connectors.shdr.shdr_connector.SHDRConnector`.
+    """
+    type: Literal['shdr'] = Field(
+        ...,  # no default, means required
+        description="Discriminator field to identify SHDR connector type."
+    )
+
+    host: IPvAnyAddress = Field(
+        ...,
+        description="SHDR server IP address."
+    )
+
+    port: int = Field(
+        ...,
+        ge=1,
+        le=65535,
+        description="SHDR server port."
+    )
+
+    data: Dict[str, SHDRDataPointSchema] = Field(
+        default_factory=dict,
+        description="Dictionary of SHDR data point definitions."
+    )
+
+    model_config = ConfigDict(extra="forbid", frozen=True)

--- a/openfactory/schemas/connectors/types.py
+++ b/openfactory/schemas/connectors/types.py
@@ -20,10 +20,11 @@ from typing import Annotated
 from pydantic import Field
 from openfactory.schemas.connectors.mtconnect import MTConnectConnectorSchema
 from openfactory.schemas.connectors.opcua import OPCUAConnectorSchema
+from openfactory.schemas.connectors.shdr import SHDRConnectorSchema
 
 
 Connector = Annotated[
-    MTConnectConnectorSchema | OPCUAConnectorSchema,  # Add other connector models here as needed
+    MTConnectConnectorSchema | OPCUAConnectorSchema | SHDRConnectorSchema,  # Add other connector models here as needed
     Field(
         discriminator='type',
         description="Discriminator field to select the correct connector schema based on the 'type' value."

--- a/tests/openfactory/schemas/connectors/test_shdr_connector.py
+++ b/tests/openfactory/schemas/connectors/test_shdr_connector.py
@@ -1,0 +1,343 @@
+import unittest
+from pydantic import ValidationError
+from openfactory.schemas.connectors.shdr import SHDRDataPointSchema, SHDRConnectorSchema
+
+
+class TestSHDRConnectorSchema(unittest.TestCase):
+    """ Unit tests for SHDRConnectorSchema """
+
+    def test_valid_connector_schema_minimal(self):
+        """ Valid minimal connector schema """
+        data = {
+            "type": "shdr",
+            "host": "127.0.0.1",
+            "port": 7878,
+            "data": {
+                "temp": {
+                    "tag": "Temperature",
+                    "type": "Samples"
+                }
+            }
+        }
+
+        schema = SHDRConnectorSchema(**data)
+
+        self.assertEqual(schema.type, "shdr")
+        self.assertEqual(str(schema.host), "127.0.0.1")
+        self.assertEqual(schema.port, 7878)
+
+        temp = schema.data["temp"]
+
+        self.assertIsInstance(temp, SHDRDataPointSchema)
+        self.assertEqual(temp.tag, "Temperature")
+        self.assertEqual(temp.type, "Samples")
+
+    def test_missing_type_field_raises(self):
+        """ Missing 'type' field should raise ValidationError """
+        data = {
+            "host": "127.0.0.1",
+            "port": 7878,
+            "data": {
+                "temp": {
+                    "tag": "Temperature",
+                    "type": "Samples"
+                }
+            }
+        }
+
+        with self.assertRaises(ValidationError) as cm:
+            SHDRConnectorSchema(**data)
+
+        errors = cm.exception.errors()
+
+        self.assertEqual(errors[0]["loc"], ("type",))
+        self.assertEqual(errors[0]["type"], "missing")
+
+    def test_invalid_type_field_raises(self):
+        """ Invalid connector type should raise ValidationError """
+        data = {
+            "type": "does_not_exist",
+            "host": "127.0.0.1",
+            "port": 7878,
+            "data": {
+                "temp": {
+                    "tag": "Temperature",
+                    "type": "Samples"
+                }
+            }
+        }
+
+        with self.assertRaises(ValidationError) as cm:
+            SHDRConnectorSchema(**data)
+
+        errors = cm.exception.errors()
+
+        self.assertEqual(errors[0]["loc"], ("type",))
+        self.assertEqual(errors[0]["type"], "literal_error")
+
+    def test_missing_host_raises(self):
+        """ Missing host should raise ValidationError """
+        data = {
+            "type": "shdr",
+            "port": 7878,
+            "data": {
+                "temp": {
+                    "tag": "Temperature",
+                    "type": "Samples"
+                }
+            }
+        }
+
+        with self.assertRaises(ValidationError) as cm:
+            SHDRConnectorSchema(**data)
+
+        errors = cm.exception.errors()
+
+        self.assertEqual(errors[0]["loc"], ("host",))
+        self.assertEqual(errors[0]["type"], "missing")
+
+    def test_invalid_host_raises(self):
+        """ Invalid IP address should raise ValidationError """
+        data = {
+            "type": "shdr",
+            "host": "not-an-ip",
+            "port": 7878,
+            "data": {
+                "temp": {
+                    "tag": "Temperature",
+                    "type": "Samples"
+                }
+            }
+        }
+
+        with self.assertRaises(ValidationError) as cm:
+            SHDRConnectorSchema(**data)
+
+        errors = cm.exception.errors()
+
+        self.assertEqual(errors[0]["loc"], ("host",))
+        self.assertEqual(errors[0]["type"], "ip_any_address")
+
+    def test_missing_port_raises(self):
+        """ Missing port should raise ValidationError """
+        data = {
+            "type": "shdr",
+            "host": "127.0.0.1",
+            "data": {
+                "temp": {
+                    "tag": "Temperature",
+                    "type": "Samples"
+                }
+            }
+        }
+
+        with self.assertRaises(ValidationError) as cm:
+            SHDRConnectorSchema(**data)
+
+        errors = cm.exception.errors()
+
+        self.assertEqual(errors[0]["loc"], ("port",))
+        self.assertEqual(errors[0]["type"], "missing")
+
+    def test_invalid_port_low_raises(self):
+        """ Port lower than 1 should raise ValidationError """
+        data = {
+            "type": "shdr",
+            "host": "127.0.0.1",
+            "port": 0,
+            "data": {
+                "temp": {
+                    "tag": "Temperature",
+                    "type": "Samples"
+                }
+            }
+        }
+
+        with self.assertRaises(ValidationError) as cm:
+            SHDRConnectorSchema(**data)
+
+        errors = cm.exception.errors()
+
+        self.assertEqual(errors[0]["loc"], ("port",))
+        self.assertEqual(errors[0]["type"], "greater_than_equal")
+
+    def test_invalid_port_high_raises(self):
+        """ Port higher than 65535 should raise ValidationError """
+        data = {
+            "type": "shdr",
+            "host": "127.0.0.1",
+            "port": 70000,
+            "data": {
+                "temp": {
+                    "tag": "Temperature",
+                    "type": "Samples"
+                }
+            }
+        }
+
+        with self.assertRaises(ValidationError) as cm:
+            SHDRConnectorSchema(**data)
+
+        errors = cm.exception.errors()
+
+        self.assertEqual(errors[0]["loc"], ("port",))
+        self.assertEqual(errors[0]["type"], "less_than_equal")
+
+    def test_missing_data_point_tag_raises(self):
+        """ Missing tag in data point should raise ValidationError """
+        data = {
+            "type": "shdr",
+            "host": "127.0.0.1",
+            "port": 7878,
+            "data": {
+                "temp": {
+                    "type": "Samples"
+                }
+            }
+        }
+
+        with self.assertRaises(ValidationError) as cm:
+            SHDRConnectorSchema(**data)
+
+        errors = cm.exception.errors()
+
+        self.assertEqual(errors[0]["loc"], ("data", "temp", "tag"))
+        self.assertEqual(errors[0]["type"], "missing")
+
+    def test_missing_data_point_type_raises(self):
+        """ Missing type in data point should raise ValidationError """
+        data = {
+            "type": "shdr",
+            "host": "127.0.0.1",
+            "port": 7878,
+            "data": {
+                "temp": {
+                    "tag": "Temperature"
+                }
+            }
+        }
+
+        with self.assertRaises(ValidationError) as cm:
+            SHDRConnectorSchema(**data)
+
+        errors = cm.exception.errors()
+
+        self.assertEqual(errors[0]["loc"], ("data", "temp", "type"))
+        self.assertEqual(errors[0]["type"], "missing")
+
+    def test_invalid_data_point_type_raises(self):
+        """ Invalid data point type should raise ValidationError """
+        data = {
+            "type": "shdr",
+            "host": "127.0.0.1",
+            "port": 7878,
+            "data": {
+                "temp": {
+                    "tag": "Temperature",
+                    "type": "Invalid"
+                }
+            }
+        }
+
+        with self.assertRaises(ValidationError) as cm:
+            SHDRConnectorSchema(**data)
+
+        errors = cm.exception.errors()
+
+        self.assertEqual(errors[0]["loc"], ("data", "temp", "type"))
+        self.assertEqual(errors[0]["type"], "literal_error")
+
+    def test_multiple_data_points(self):
+        """ Multiple data points are parsed correctly """
+        data = {
+            "type": "shdr",
+            "host": "127.0.0.1",
+            "port": 7878,
+            "data": {
+                "temp": {
+                    "tag": "Temperature",
+                    "type": "Samples"
+                },
+                "humi": {
+                    "tag": "Humidity",
+                    "type": "Events"
+                }
+            }
+        }
+
+        schema = SHDRConnectorSchema(**data)
+
+        self.assertEqual(schema.data["temp"].tag, "Temperature")
+        self.assertEqual(schema.data["temp"].type, "Samples")
+
+        self.assertEqual(schema.data["humi"].tag, "Humidity")
+        self.assertEqual(schema.data["humi"].type, "Events")
+
+    def test_duplicate_tags_allowed(self):
+        """ Multiple data points can use the same SHDR tag """
+        data = {
+            "type": "shdr",
+            "host": "127.0.0.1",
+            "port": 7878,
+            "data": {
+                "temp1": {
+                    "tag": "Temperature",
+                    "type": "Samples"
+                },
+                "temp2": {
+                    "tag": "Temperature",
+                    "type": "Events"
+                }
+            }
+        }
+
+        schema = SHDRConnectorSchema(**data)
+
+        self.assertEqual(schema.data["temp1"].tag, "Temperature")
+        self.assertEqual(schema.data["temp2"].tag, "Temperature")
+
+    def test_extra_top_level_field_forbidden(self):
+        """ Unknown top-level fields should raise ValidationError """
+        data = {
+            "type": "shdr",
+            "host": "127.0.0.1",
+            "port": 7878,
+            "foo": "bar",
+            "data": {
+                "temp": {
+                    "tag": "Temperature",
+                    "type": "Samples"
+                }
+            }
+        }
+
+        with self.assertRaises(ValidationError) as cm:
+            SHDRConnectorSchema(**data)
+
+        errors = cm.exception.errors()
+
+        self.assertEqual(errors[0]["loc"], ("foo",))
+        self.assertEqual(errors[0]["type"], "extra_forbidden")
+
+    def test_extra_data_point_field_forbidden(self):
+        """ Unknown fields in data point should raise ValidationError """
+        data = {
+            "type": "shdr",
+            "host": "127.0.0.1",
+            "port": 7878,
+            "data": {
+                "temp": {
+                    "tag": "Temperature",
+                    "type": "Samples",
+                    "foo": "bar"
+                }
+            }
+        }
+
+        with self.assertRaises(ValidationError) as cm:
+            SHDRConnectorSchema(**data)
+
+        errors = cm.exception.errors()
+
+        self.assertEqual(errors[0]["loc"], ("data", "temp", "foo"))
+        self.assertEqual(errors[0]["type"], "extra_forbidden")


### PR DESCRIPTION
Introduces validated Pydantic schemas for SHDR connector configurations.

These schemas provide the foundation for future SHDR connector runtime support inside OpenFactory.

The implementation includes:

* SHDR connector schema
* SHDR data point schema
* strict validation rules
* immutable validated configuration models

### Added Schemas

#### `SHDRDataPointSchema`

Represents a single SHDR data point configuration.

Fields:

* `tag`
* `type`

Supported types:

* `Samples`
* `Events`

#### `SHDRConnectorSchema`

Represents the SHDR connector configuration.

Fields:

* `type`
* `host`
* `port`
* `data`

### Validation Features

The schema validates:

* IPv4/IPv6 addresses
* TCP port range (`1-65535`)
* allowed SHDR stream types
* strict schema conformance (`extra="forbid"`)

Models are immutable using:

```python id="j6m3ye"
ConfigDict(frozen=True)
```

### Example Configuration

```yaml id="g4r9pw"
connector:
  type: shdr

  host: 192.168.1.10
  port: 7878

  data:
    temp:
      tag: Temperature
      type: Samples

    humi:
      tag: Humidity
      type: Events
```

### Notes

This PR introduces only the schema/configuration layer.

The runtime SHDR connector implementation will be introduced in a separate PR.
