### PR TITLE
Allow Hostnames in SHDR Connector Configuration

### DIFF
--- a/openfactory/schemas/connectors/shdr.py
+++ b/openfactory/schemas/connectors/shdr.py
@@ -19,7 +19,6 @@ Key Models:
 
 Validation Features:
 --------------------
-- Validates ``host`` as a valid IPv4 or IPv6 address.
 - Validates ``port`` range (1-65535).
 - Restricts SHDR data point ``type`` to ``Samples`` or ``Events``.
 - Forbids unknown fields to ensure strict schema conformance.

--- a/openfactory/schemas/connectors/shdr.py
+++ b/openfactory/schemas/connectors/shdr.py
@@ -50,7 +50,7 @@ YAML Example:
 """
 
 from typing import Literal, Dict
-from pydantic import BaseModel, ConfigDict, Field, IPvAnyAddress
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class SHDRDataPointSchema(BaseModel):
@@ -84,9 +84,9 @@ class SHDRConnectorSchema(BaseModel):
         description="Discriminator field to identify SHDR connector type."
     )
 
-    host: IPvAnyAddress = Field(
+    host: str = Field(
         ...,
-        description="SHDR server IP address."
+        description="SHDR server hostname or IP address.",
     )
 
     port: int = Field(

--- a/tests/openfactory/schemas/connectors/test_shdr_connector.py
+++ b/tests/openfactory/schemas/connectors/test_shdr_connector.py
@@ -96,11 +96,11 @@ class TestSHDRConnectorSchema(unittest.TestCase):
         self.assertEqual(errors[0]["loc"], ("host",))
         self.assertEqual(errors[0]["type"], "missing")
 
-    def test_invalid_host_raises(self):
-        """ Invalid IP address should raise ValidationError """
+    def test_hostname_is_accepted(self):
+        """ Hostnames are accepted as SHDR server hosts """
         data = {
             "type": "shdr",
-            "host": "not-an-ip",
+            "host": "shdr-server",
             "port": 7878,
             "data": {
                 "temp": {
@@ -110,13 +110,9 @@ class TestSHDRConnectorSchema(unittest.TestCase):
             }
         }
 
-        with self.assertRaises(ValidationError) as cm:
-            SHDRConnectorSchema(**data)
+        schema = SHDRConnectorSchema(**data)
 
-        errors = cm.exception.errors()
-
-        self.assertEqual(errors[0]["loc"], ("host",))
-        self.assertEqual(errors[0]["type"], "ip_any_address")
+        self.assertEqual(schema.host, "shdr-server")
 
     def test_missing_port_raises(self):
         """ Missing port should raise ValidationError """


### PR DESCRIPTION
This PR updates the SHDR connector schema to accept hostnames in addition to IP addresses for the `host` field.

## Changes

### Schema

Updated the `host` field in `SHDRConnectorSchema`:

```python
host: IPvAnyAddress
```

becomes:

```python
host: str
```

This allows configurations such as:

```yaml
connectors:
  shdr:
    type: shdr
    host: shdr-server
    port: 7878
```

in addition to traditional IP-based configurations:

```yaml
connectors:
  shdr:
    type: shdr
    host: 192.168.1.10
    port: 7878
```

## Motivation

The previous implementation restricted the `host` field to IP addresses only. This prevented common deployment patterns based on DNS names and container service names.

Examples that should be supported include:

* Docker Compose service names
* Kubernetes service names
* Internal DNS hostnames
* Traditional FQDNs

Since the networking stack already performs hostname resolution during connection establishment, schema validation should not unnecessarily reject valid hostnames.

## Backward Compatibility

This change is fully backward compatible.

Existing configurations using IPv4 and IPv6 addresses continue to work unchanged.
