### PR TITLE
Perform Graceful Shutdown Before Removing Local Docker Containers

### DIFF
--- a/openfactory/openfactory_deploy_strategy.py
+++ b/openfactory/openfactory_deploy_strategy.py
@@ -274,4 +274,5 @@ class LocalDockerDeploymentStrategy(OpenFactoryServiceDeploymentStrategy):
         """
         client = docker.from_env()
         container = client.containers.get(service_name)
-        container.remove(force=True)
+        container.stop()
+        container.remove()

--- a/tests/openfactory/test_openfactory_deploy_strategy.py
+++ b/tests/openfactory/test_openfactory_deploy_strategy.py
@@ -179,7 +179,7 @@ class TestLocalDockerDeploymentStrategy(unittest.TestCase):
 
     @patch("openfactory.openfactory_deploy_strategy.docker.from_env")
     def test_local_remove(self, mock_from_env):
-        """ Test local Docker remove method using direct docker.from_env() """
+        """ Test local Docker remove performs a graceful shutdown before removal. """
         mock_docker_client = MagicMock()
         mock_container = MagicMock()
         mock_docker_client.containers.get.return_value = mock_container
@@ -189,7 +189,18 @@ class TestLocalDockerDeploymentStrategy(unittest.TestCase):
         strategy.remove("test-container")
 
         mock_docker_client.containers.get.assert_called_once_with("test-container")
-        mock_container.remove.assert_called_once_with(force=True)
+
+        # Verify graceful shutdown sequence
+        self.assertEqual(
+            mock_container.method_calls,
+            [
+                unittest.mock.call.stop(),
+                unittest.mock.call.remove(),
+            ]
+        )
+
+        mock_container.stop.assert_called_once_with()
+        mock_container.remove.assert_called_once_with()
 
     @patch("openfactory.openfactory_deploy_strategy.docker.from_env")
     @patch("openfactory.openfactory_deploy_strategy.Mount")


### PR DESCRIPTION
This PR fixes a bug in the local Docker deployment strategy where undeploying an application forcibly removed the container without giving the application an opportunity to execute its shutdown logic.

The local deployment strategy now performs a graceful container stop before removing the container.

## Problem

The local Docker deployment strategy previously removed containers using:

```python
container.remove(force=True)
```

This caused the container to be terminated immediately, preventing OpenFactory applications from performing cleanup operations during shutdown.

As a consequence:

* SIGTERM handlers were not executed.
* Asset deregistration could be skipped.
* Connector teardown could be skipped.
* Application shutdown hooks could be skipped.
* Local Docker deployments behaved differently from Docker Swarm deployments.

## Root Cause

The issue only affected standalone Docker deployments.

Docker Swarm deployments already use:

```python
service.remove()
```

which performs a graceful service shutdown before removing the service.

As a result, shutdown logic worked correctly when testing on Docker Swarm but not when testing with standalone Docker containers.

## Changes

Updated the local Docker undeploy implementation from:

```python
container.remove(force=True)
```

to:

```python
container.stop()
container.remove()
```

This allows Docker to send SIGTERM to the application and wait for a graceful shutdown before removing the container.

## Test Updates

Updated `test_local_remove` to verify the graceful shutdown sequence.

The test now validates that:

```python
container.stop()
container.remove()
```

are invoked in the correct order.

This protects against future regressions that could reintroduce forced container removal.

## Benefits

* Consistent behavior between local Docker and Docker Swarm deployments.
* OpenFactory applications receive shutdown signals during undeploy.
* Asset deregistration is performed reliably.
* Connector teardown is performed reliably.
* Local development environment more accurately reflects production behavior.

