### PR TITLE
Centralize Application Shutdown Through an Idempotent Shutdown Mechanism

### DIFF
--- a/openfactory/apps/ofa_fastapi_app.py
+++ b/openfactory/apps/ofa_fastapi_app.py
@@ -360,7 +360,7 @@ class OpenFactoryFastAPIApp(OpenFactoryApp):
 
             # OpenFactory cleanup
             try:
-                self.app_event_loop_stopped()
+                self.shutdown()
             except Exception:
                 pass
 

--- a/openfactory/apps/ofa_flask_app.py
+++ b/openfactory/apps/ofa_flask_app.py
@@ -494,7 +494,7 @@ class OpenFactoryFlaskApp(OpenFactoryApp):
 
             # cleanup
             try:
-                self.app_event_loop_stopped()
+                self.shutdown()
             except Exception:
                 self.logger.exception("Cleanup failed")
 

--- a/openfactory/apps/ofaapp.py
+++ b/openfactory/apps/ofaapp.py
@@ -150,6 +150,8 @@ class OpenFactoryApp(Asset, metaclass=OpenFactoryAppMeta):
                          bootstrap_servers=bootstrap_servers, asset_router_url=asset_router_url,
                          test_mode=test_mode)
 
+        self._shutdown_completed = False
+
         # setup logging
         self.logger = configure_prefixed_logger(
             app_uuid,
@@ -321,6 +323,23 @@ class OpenFactoryApp(Asset, metaclass=OpenFactoryAppMeta):
         """ Called when main loop is stopped. """
         pass
 
+    def shutdown(self) -> None:
+        """
+        Shutdown the application and execute cleanup logic.
+
+        This method is idempotent and may be called multiple times safely.
+        """
+        if self._shutdown_completed:
+            return
+
+        self._shutdown_completed = True
+        deregister_asset(
+            self.asset_uuid,
+            ksqlClient=self.ksql,
+            bootstrap_servers=self.bootstrap_servers
+        )
+        self.app_event_loop_stopped()
+
     def signal_handler(self, signum: int, frame: Optional[FrameType]) -> None:
         """
         Handles ``SIGINT`` and ``SIGTERM`` signals, gracefully stopping the application.
@@ -335,8 +354,7 @@ class OpenFactoryApp(Asset, metaclass=OpenFactoryAppMeta):
         """
         signal_name = signal.Signals(signum).name
         self.logger.info(f"Received signal {signal_name}, stopping app gracefully ...")
-        deregister_asset(self.asset_uuid, ksqlClient=self.ksql, bootstrap_servers=self.bootstrap_servers)
-        self.app_event_loop_stopped()
+        self.shutdown()
         exit(0)
 
     def main_loop(self) -> None:
@@ -386,11 +404,9 @@ class OpenFactoryApp(Asset, metaclass=OpenFactoryAppMeta):
         self.logger.info("Starting main loop")
         try:
             self.main_loop()
-
         except Exception:
             self.logger.exception("An error occurred in the main_loop of the app.")
-            self.app_event_loop_stopped()
-            deregister_asset(self.asset_uuid, ksqlClient=self.ksql, bootstrap_servers=self.bootstrap_servers)
+            self.shutdown()
 
     async def async_main_loop(self) -> None:
         """
@@ -437,8 +453,7 @@ class OpenFactoryApp(Asset, metaclass=OpenFactoryAppMeta):
             await self.async_main_loop()
         except Exception:
             self.logger.exception("An error occurred in the async main loop")
-            self.app_event_loop_stopped()
-            deregister_asset(self.asset_uuid, ksqlClient=self.ksql, bootstrap_servers=self.bootstrap_servers)
+            self.shutdown()
 
 
 if __name__ == "__main__":

--- a/tests/openfactory/apps/test_openfactory_fastapi_app.py
+++ b/tests/openfactory/apps/test_openfactory_fastapi_app.py
@@ -153,8 +153,8 @@ class TestOpenFactoryFastAPIAppAsync(unittest.IsolatedAsyncioTestCase):
 
         app._run_fastapi.assert_awaited_once()
 
-    async def test_async_run_failure_triggers_cleanup(self):
-        """ Test async_run failure triggers cleanup """
+    async def test_async_run_failure_triggers_shutdown(self):
+        """ Verify async_run invokes shutdown when FastAPI task crashes. """
         app = _TestApp(
             ksqlClient=self.ksql_mock,
             bootstrap_servers='mock',
@@ -166,11 +166,11 @@ class TestOpenFactoryFastAPIAppAsync(unittest.IsolatedAsyncioTestCase):
             raise RuntimeError("boom")
 
         app._run_fastapi = failing_fastapi
-        app.app_event_loop_stopped = MagicMock()
+        app.shutdown = MagicMock()
 
         await app.async_run()
 
-        app.app_event_loop_stopped.assert_called_once()
+        app.shutdown.assert_called_once()
 
     async def test_uvicorn_shutdown_flag(self):
         """ Test uvicorn shutdown flag """

--- a/tests/openfactory/apps/test_openfactory_flask_app.py
+++ b/tests/openfactory/apps/test_openfactory_flask_app.py
@@ -287,8 +287,8 @@ class TestOpenFactoryFlaskAppAsync(unittest.IsolatedAsyncioTestCase):
 
         app._run_flask.assert_called_once()
 
-    async def test_async_run_failure_triggers_cleanup(self):
-        """ Test async_run failure triggers cleanup """
+    async def test_async_run_failure_triggers_shutdown(self):
+        """ Verify async_run invokes shutdown when Flask thread crashes. """
 
         app = _TestApp(
             ksqlClient=self.ksql_mock,
@@ -301,10 +301,11 @@ class TestOpenFactoryFlaskAppAsync(unittest.IsolatedAsyncioTestCase):
             raise RuntimeError("boom")
 
         app._run_flask = failing_flask
-        app.app_event_loop_stopped = MagicMock()
+        app.shutdown = MagicMock()
+
         await app.async_run()
 
-        app.app_event_loop_stopped.assert_called_once()
+        app.shutdown.assert_called_once()
 
     async def test_default_async_main_loop_cancel(self):
         """ Ensure default async_main_loop is cancellable """
@@ -376,3 +377,23 @@ class TestOpenFactoryFlaskAppAsync(unittest.IsolatedAsyncioTestCase):
             app._thread_wrapper(failing)
 
         self.assertIsInstance(app._thread_exception, RuntimeError)
+
+    async def test_async_run_shutdown_is_only_executed_once(self):
+        """ Verify async_run does not execute cleanup twice. """
+        app = _TestApp(
+            ksqlClient=self.ksql_mock,
+            bootstrap_servers="mock",
+            asset_router_url="mock",
+            test_mode=True
+        )
+
+        app.shutdown = MagicMock()
+
+        def failing_flask():
+            raise RuntimeError("boom")
+
+        app._run_flask = failing_flask
+
+        await app.async_run()
+
+        app.shutdown.assert_called_once()

--- a/tests/openfactory/apps/test_openfactoryapp.py
+++ b/tests/openfactory/apps/test_openfactoryapp.py
@@ -267,42 +267,38 @@ class TestOpenFactoryApp(unittest.TestCase):
         self.assertIn("Setup OpenFactory App DEV-UUID", calls)
 
     def test_signal_sigint(self):
-        """ Test signal SIGINT """
-        app = OpenFactoryApp(ksqlClient=self.ksql_mock,
-                             bootstrap_servers='mock_bootstrap', asset_router_url='mocked_asset_url')
-        app.app_event_loop_stopped = MagicMock()
+        """ Verify SIGINT delegates to shutdown. """
+        app = OpenFactoryApp(
+            ksqlClient=self.ksql_mock,
+            bootstrap_servers="mock_bootstrap",
+            asset_router_url="mocked_asset_url"
+        )
 
-        with patch('openfactory.apps.ofaapp.signal.Signals') as mock_signals:
-            mock_signals.return_value.name = 'SIGINT'
-            # Assert that SystemExit is raised
+        app.shutdown = MagicMock()
+
+        with patch("openfactory.apps.ofaapp.signal.Signals") as mock_signals:
+            mock_signals.return_value.name = "SIGINT"
             with self.assertRaises(SystemExit):
                 app.signal_handler(signal.SIGINT, None)
 
-        # Check that deregister_asset was called with the expected arguments
-        self.mock_deregister.assert_called_once_with(
-            'DEV-UUID', ksqlClient=self.ksql_mock, bootstrap_servers='mock_bootstrap'
-        )
-        # Check app_event_loop_stopped was called
-        app.app_event_loop_stopped.assert_called_once()
+        app.shutdown.assert_called_once()
 
     def test_signal_sigterm(self):
-        """ Test signal SIGTERM """
-        app = OpenFactoryApp(ksqlClient=self.ksql_mock,
-                             bootstrap_servers='mock_bootstrap', asset_router_url='mocked_asset_url')
-        app.app_event_loop_stopped = MagicMock()
-
-        with patch('openfactory.apps.ofaapp.signal.Signals') as mock_signals:
-            mock_signals.return_value.name = 'SIGTERM'
-            # Assert that SystemExit is raised
-            with self.assertRaises(SystemExit):
-                app.signal_handler(signal.SIGINT, None)
-
-        # Check that deregister_asset was called with the expected arguments
-        self.mock_deregister.assert_called_once_with(
-            'DEV-UUID', ksqlClient=self.ksql_mock, bootstrap_servers='mock_bootstrap'
+        """ Verify SIGTERM delegates to shutdown. """
+        app = OpenFactoryApp(
+            ksqlClient=self.ksql_mock,
+            bootstrap_servers="mock_bootstrap",
+            asset_router_url="mocked_asset_url"
         )
-        # Check app_event_loop_stopped was called
-        app.app_event_loop_stopped.assert_called_once()
+
+        app.shutdown = MagicMock()
+
+        with patch("openfactory.apps.ofaapp.signal.Signals") as mock_signals:
+            mock_signals.return_value.name = "SIGTERM"
+            with self.assertRaises(SystemExit):
+                app.signal_handler(signal.SIGTERM, None)
+
+        app.shutdown.assert_called_once()
 
     def test_main_loop_not_implemented(self):
         """ Test call to main_loop raise NotImplementedError """
@@ -320,20 +316,85 @@ class TestOpenFactoryApp(unittest.TestCase):
         app.main_loop.assert_called_once()
 
     def test_run_handles_main_loop_exception(self):
-        """ Test handling of exception in main_loop """
+        """ Verify run() invokes shutdown on main loop failure. """
         app = OpenFactoryApp(
             ksqlClient=self.ksql_mock,
-            bootstrap_servers='mock_bootstrap',
-            asset_router_url='mocked_asset_url'
+            bootstrap_servers="mock_bootstrap",
+            asset_router_url="mocked_asset_url"
         )
-        app.main_loop = MagicMock(side_effect=Exception("Boom"))
 
-        with patch.object(app.logger, 'exception') as mock_logger_exception:
-            app.run()
-            mock_logger_exception.assert_called_once()
-            args, kwargs = mock_logger_exception.call_args
-            assert "An error occurred in the main_loop of the app." in args[0]
-            self.mock_deregister.assert_called_once()
+        app.main_loop = MagicMock(side_effect=Exception("Boom"))
+        app.shutdown = MagicMock()
+
+        app.run()
+
+        app.shutdown.assert_called_once()
+
+    def test_shutdown_is_idempotent(self):
+        """ Verify shutdown() executes cleanup only once. """
+        app = OpenFactoryApp(
+            ksqlClient=self.ksql_mock,
+            bootstrap_servers="mock_bootstrap",
+            asset_router_url="mocked_asset_url"
+        )
+
+        app.app_event_loop_stopped = MagicMock()
+
+        app.shutdown()
+        app.shutdown()
+        app.shutdown()
+
+        self.mock_deregister.assert_called_once_with(
+            "DEV-UUID",
+            ksqlClient=self.ksql_mock,
+            bootstrap_servers="mock_bootstrap"
+        )
+        app.app_event_loop_stopped.assert_called_once()
+        self.assertTrue(app._shutdown_completed)
+
+    def test_shutdown_after_signal_handler_is_noop(self):
+        """ Verify shutdown() becomes a no-op after signal_handler already performed cleanup. """
+        app = OpenFactoryApp(
+            ksqlClient=self.ksql_mock,
+            bootstrap_servers="mock_bootstrap",
+            asset_router_url="mocked_asset_url"
+        )
+
+        app.app_event_loop_stopped = MagicMock()
+
+        with patch("openfactory.apps.ofaapp.signal.Signals") as mock_signals:
+            mock_signals.return_value.name = "SIGINT"
+            with self.assertRaises(SystemExit):
+                app.signal_handler(signal.SIGINT, None)
+
+        # Simulate a second shutdown path (e.g. FastAPI/Flask runtime cleanup)
+        app.shutdown()
+
+        # Cleanup should only have happened once
+        self.mock_deregister.assert_called_once_with(
+            "DEV-UUID",
+            ksqlClient=self.ksql_mock,
+            bootstrap_servers="mock_bootstrap"
+        )
+        app.app_event_loop_stopped.assert_called_once()
+        self.assertTrue(app._shutdown_completed)
+
+    def test_signal_handler_calls_shutdown(self):
+        """ Signal handler should delegate cleanup to shutdown(). """
+        app = OpenFactoryApp(
+            ksqlClient=self.ksql_mock,
+            bootstrap_servers="mock_bootstrap",
+            asset_router_url="mocked_asset_url"
+        )
+
+        app.shutdown = MagicMock()
+
+        with patch("openfactory.apps.ofaapp.signal.Signals") as mock_signals:
+            mock_signals.return_value.name = "SIGINT"
+            with self.assertRaises(SystemExit):
+                app.signal_handler(signal.SIGINT, None)
+
+        app.shutdown.assert_called_once()
 
 
 class TestOpenFactoryAppAsync(unittest.IsolatedAsyncioTestCase):
@@ -399,36 +460,17 @@ class TestOpenFactoryAppAsync(unittest.IsolatedAsyncioTestCase):
         app.async_main_loop.assert_awaited_once()
 
     async def test_async_run_handles_exception(self):
-        """ Verify async_run handles exceptions from async_main_loop. """
-        app = OpenFactoryApp(bootstrap_servers='mocked_broker', asset_router_url='mocked_asset_url',
-                             ksqlClient=self.ksql_mock)
+        """ async_run() should shutdown on async main loop failure. """
 
-        # Patch async_main_loop to raise an exception
-        app.async_main_loop = AsyncMock(side_effect=Exception("Boom!"))
+        app = OpenFactoryApp(
+            ksqlClient=self.ksql_mock,
+            bootstrap_servers="mocked_broker",
+            asset_router_url="mocked_asset_url"
+        )
 
-        # Patch welcome_banner to avoid side effects
-        app.welcome_banner = lambda: None
-
-        # Patch add_attribute
-        app.add_attribute = lambda *a, **k: None
-
-        # Patch logger to avoid actual logging
-        app.logger = unittest.mock.Mock()
-
-        # Patch deregister_asset and app_event_loop_stopped
-        app.app_event_loop_stopped = unittest.mock.Mock()
+        app.async_main_loop = AsyncMock(side_effect=Exception("Boom"))
+        app.shutdown = MagicMock()
 
         await app.async_run()
 
-        # Check app_event_loop_stopped called
-        app.app_event_loop_stopped.assert_called_once()
-
-        # Check deregister_asset called with asset_uuid
-        self.mock_deregister.assert_called_once_with(
-            app.asset_uuid,
-            ksqlClient=app.ksql,
-            bootstrap_servers=app.bootstrap_servers
-        )
-
-        # Check logger.exception called
-        app.logger.exception.assert_called()
+        app.shutdown.assert_called_once()


### PR DESCRIPTION
# Centralize Application Shutdown Through an Idempotent Shutdown Mechanism

## Summary

This PR centralizes application cleanup in a single idempotent `shutdown()` method implemented in `OpenFactoryApp`.

Previously, shutdown responsibilities were distributed across multiple execution paths, which could result in cleanup logic being executed multiple times during application termination.

This change ensures that application cleanup is performed exactly once, regardless of how shutdown is triggered.

## Problem

Cleanup logic was previously duplicated across multiple runtime implementations and shutdown paths.

Examples included:

* Signal handlers
* Exception handlers
* FastAPI runtime shutdown
* Flask runtime shutdown

As a consequence, operations such as:

* Asset deregistration
* Connector teardown
* Custom `app_event_loop_stopped()` logic

could be executed multiple times.

Observed behavior:

```text
Received signal SIGINT, stopping app gracefully ...
Deconnect SHDR Probe
SHDR device SHDR-PROBE deregistered successfully
done

Shutting down application
Deconnect SHDR Probe
SHDR device SHDR-PROBE deregistered successfully
done

Application shutdown complete
```

In this example, the SHDR connector teardown and deregistration were executed twice.

## Root Cause

Shutdown responsibilities were implemented independently in multiple framework components.

There was no centralized framework-level shutdown mechanism.

Multiple execution paths directly invoked:

```python
deregister_asset(...)
```

and

```python
app_event_loop_stopped()
```

resulting in duplicated cleanup.

## Solution

A new centralized shutdown mechanism has been introduced in `OpenFactoryApp`.

```python
def shutdown(self) -> None:
    ...
```

The shutdown method:

* Performs application cleanup.
* Deregisters assets.
* Invokes `app_event_loop_stopped()`.
* Is idempotent and safe to call multiple times.

All runtime implementations now delegate cleanup to this method.

## Changes

### OpenFactoryApp

* Added centralized `shutdown()` method.
* Added shutdown state tracking to prevent duplicate cleanup.
* Updated signal handler to delegate to `shutdown()`.
* Updated exception handling paths to delegate to `shutdown()`.

### OpenFactoryFastAPIApp

* Removed direct cleanup logic.
* Delegates application cleanup through `shutdown()`.

### OpenFactoryFlaskApp

* Removed direct cleanup logic.
* Delegates application cleanup through `shutdown()`.

## Test Suite Updates

### OpenFactoryApp

Added tests for:

* Shutdown idempotency.
* Shutdown after signal handling.
* Exception-triggered shutdown.
* Signal-handler delegation.

### OpenFactoryFastAPIApp

Updated tests to validate:

```python
shutdown()
```

delegation rather than direct cleanup implementation details.

### OpenFactoryFlaskApp

Updated tests to validate:

```python
shutdown()
```

delegation rather than direct cleanup implementation details.

## Benefits

* Cleanup executes exactly once.
* Asset deregistration executes exactly once.
* Connector teardown executes exactly once.
* Consistent behavior across all application runtimes.
* Reduced risk of shutdown-related bugs.
* Simpler lifecycle management.
* Improved test coverage for shutdown behavior.

## Validation

Before:

```text
Received signal SIGINT...
Deconnect SHDR Probe
done

Shutting down application
Deconnect SHDR Probe
done
```

After:

```text
Received signal SIGINT...
Deconnect SHDR Probe
done

Shutting down application
Application shutdown complete
```

The cleanup sequence is now executed exactly once regardless of how many shutdown paths converge on the application.

## Backward Compatibility

This change is fully backward compatible.

Existing applications based on:

* `OpenFactoryApp`
* `OpenFactoryFastAPIApp`
* `OpenFactoryFlaskApp`

require no modifications.
