### PR TITLE
Avoid attempting to connect to docker swarm if deployment platform is not swarm

### DIFF
--- a/openfactory/docker/docker_access_layer.py
+++ b/openfactory/docker/docker_access_layer.py
@@ -53,7 +53,10 @@ class DockerAccesLayer:
 
         try:
             self.docker_client = docker.DockerClient(base_url=self.docker_url)
-            swarm_attrs = self.docker_client.swarm.attrs
+            if config.DEPLOYMENT_PLATFORM == 'swarm':
+                swarm_attrs = self.docker_client.swarm.attrs
+            else:
+                swarm_attrs = []
         except docker.errors.DockerException as e:
             user_notify.warning(f"ERROR: Could not connect to Docker at {self.docker_url}: {e}")
             self.worker_token = 'UNAVAILABLE'

--- a/tests/openfactory/docker/test_docker_access_layer.py
+++ b/tests/openfactory/docker/test_docker_access_layer.py
@@ -14,6 +14,7 @@ class TestDockerAccessLayer(unittest.TestCase):
     def test_connect_success(self, mock_docker_client_class, mock_config):
         """ Test successful connection to Docker engine in Swarm mode """
         mock_config.OPENFACTORY_MANAGER_NODE_DOCKER_URL = 'tcp://127.0.0.1:2375'
+        mock_config.DEPLOYMENT_PLATFORM = 'swarm'
 
         # Prepare mock DockerClient instance
         mock_docker_client = MagicMock()
@@ -68,7 +69,7 @@ class TestDockerAccessLayer(unittest.TestCase):
     @patch('openfactory.docker.docker_access_layer.docker.DockerClient')
     def test_connect_docker_exception(self, mock_docker_client_class, mock_config, mock_user_notify):
         """ Test connection failure due to DockerException when accessing swarm.attrs """
-
+        mock_config.DEPLOYMENT_PLATFORM = 'swarm'
         mock_config.OPENFACTORY_MANAGER_NODE_DOCKER_URL = 'tcp://127.0.0.1:2375'
 
         # Raise DockerException when accessing swarm.attrs


### PR DESCRIPTION
Avoid attempting to connect to Docker swarm if `DEPLOYMENT_PLATFORM` is not `swarm`.