### PR TITLE
Add image_pull_policy to OpenFactory App schema

### DIFF
--- a/docs/guide/applications/definition.rst
+++ b/docs/guide/applications/definition.rst
@@ -6,6 +6,7 @@ They are defined declaratively using YAML.
 
 Each application describes:
     - which container image to run
+    - how container images are refreshed during deployment
     - how it integrates into the Unified Namespace (UNS)
     - how it is configured and deployed
     - how it is optionally exposed externally
@@ -27,6 +28,7 @@ Each application supports the following sections:
 
 - ``uuid`` — Asset UUID identifier of the application
 - ``image`` — Docker image to run
+- ``image_pull_policy`` — image pull behavior during deployment
 - ``runtime_uid`` — User UID in the runtime
 - ``runtime_gid`` — User GID in the runtim 
 - ``uns`` — Unified Namespace metadata
@@ -55,6 +57,25 @@ The Docker image defines the application runtime:
 .. code-block:: yaml
 
     image: ghcr.io/openfactoryio/scheduler:v1.0.3
+
+Image Pull Policy
+-----------------
+
+The ``image_pull_policy`` controls how OpenFactory obtains container images during deployment.
+
+Supported values:
+
+- ``missing`` — pull the image only if it is not available locally.
+- ``always`` — always pull the image before deployment.
+
+Example:
+
+.. code-block:: yaml
+
+    image: ghcr.io/openfactoryio/scheduler:latest
+    image_pull_policy: always
+
+This is particularly useful when using mutable image tags such as ``latest``.
 
 Runtime UID and GID
 -------------------
@@ -193,7 +214,8 @@ The ``deploy`` section defines how the application is deployed.
         apps:
           scheduler:
             uuid: "app-scheduler"
-            image: ghcr.io/openfactoryio/scheduler:v1.0.0
+            image: ghcr.io/openfactoryio/scheduler:latest
+            image_pull_policy: always
             runtime_uid: 1200
             runtime_gid: 1210
 
@@ -241,6 +263,7 @@ The ``deploy`` section defines how the application is deployed.
     - UNS metadata must match the configured schema
     - Hostnames are normalized and validated to comply with DNS rules
     - A canonical hostname is always generated when routing is enabled
+    - ``image_pull_policy: always`` is recommended when using mutable image tags such as ``latest``.
 
 .. seealso::
     - The schema of OpenFactory Apps is :class:`openfactory.schemas.apps.OpenFactoryAppSchema`.

--- a/openfactory/schemas/apps.py
+++ b/openfactory/schemas/apps.py
@@ -9,8 +9,9 @@ ensure application configurations are consistent, valid, and semantically enrich
 
 Key Components
 --------------
-- :class:`OpenFactoryAppSchema`: Defines a single application including its UUID, Docker image,
-  environment variables, UNS metadata, named storage backend, and container networks.
+- :class:`OpenFactoryAppSchema`: Defines a single application including its UUID,
+  Docker image, image pull policy, environment variables, UNS metadata,
+  named storage backend, and container networks.
 - :class:`OpenFactoryAppsConfig`: Validates a dictionary of application entries and ensures
   correct schema structure.
 - :meth:`get_apps_from_config_file`: Loads, validates, and enriches applications from a
@@ -20,6 +21,11 @@ Features
 --------
 - Supports UNS (Unified Namespace) enrichment through the ``AttachUNSMixin``.
 - Restricts configuration fields with `extra="forbid"` to ensure strict schema conformance.
+- Supports configurable image pull policies:
+
+  - ``missing``: Pull the image only if it is not available locally.
+  - ``always``: Always pull the image before deployment.
+
 - Supports multiple named storage backends, including:
 
   - ``LocalBackend``: Bind-mount a local host directory into containers (for development).
@@ -46,6 +52,7 @@ configuration YAML file, with automatic UNS enrichment.
         scheduler:
           uuid: "app-scheduler"
           image: ghcr.io/openfactoryio/scheduler:v1.0.0
+          image_pull_policy: missing
           runtime_uid: 1234
           runtime_gid: 5678
 
@@ -108,7 +115,7 @@ Note:
 import re
 import openfactory.config as Config
 from pydantic import BaseModel, Field, ValidationError, ConfigDict, field_validator, model_validator
-from typing import List, Dict, Optional, Any
+from typing import List, Dict, Optional, Any, Literal
 from openfactory.config import load_yaml
 from openfactory.models.user_notifications import user_notify
 from openfactory.schemas.uns import UNSSchema, AttachUNSMixin
@@ -238,6 +245,9 @@ class Routing(BaseModel):
             self.alias_hostname = None
 
 
+ImagePullPolicy = Literal["missing", "always"]
+
+
 class OpenFactoryAppSchema(AttachUNSMixin, BaseModel):
     """ OpenFactory Application Schema. """
     uuid: str = Field(..., description="Unique identifier for the app")
@@ -248,6 +258,15 @@ class OpenFactoryAppSchema(AttachUNSMixin, BaseModel):
     )
 
     image: str = Field(..., description="Docker image for the app")
+
+    image_pull_policy: ImagePullPolicy = Field(
+        default="missing",
+        description=(
+            "Image pull policy. "
+            "'missing' pulls only if the image is absent locally. "
+            "'always' always pulls before deployment."
+        )
+    )
 
     runtime_uid: Optional[int] = Field(
         default=None,

--- a/tests/openfactory/schemas/test_apps.py
+++ b/tests/openfactory/schemas/test_apps.py
@@ -101,6 +101,88 @@ class TestOpenFactoryAppsConfig(unittest.TestCase):
         self.assertIn("uuid", str(context.exception))
         self.assertIn("image", str(context.exception))
 
+    def test_default_image_pull_policy(self):
+        """ image_pull_policy defaults to 'missing' """
+        config = OpenFactoryAppsConfig(
+            apps={
+                "demo1": {
+                    "uuid": "DEMO-APP",
+                    "image": "demofact/demo1"
+                }
+            }
+        )
+
+        self.assertEqual(config.apps["demo1"].image_pull_policy, "missing")
+
+    def test_image_pull_policy_always(self):
+        """ image_pull_policy='always' is accepted """
+        config = OpenFactoryAppsConfig(
+            apps={
+                "demo1": {
+                    "uuid": "DEMO-APP",
+                    "image": "demofact/demo1",
+                    "image_pull_policy": "always"
+                }
+            }
+        )
+
+        self.assertEqual(config.apps["demo1"].image_pull_policy, "always")
+
+    def test_image_pull_policy_missing(self):
+        """ image_pull_policy='missing' is accepted """
+        config = OpenFactoryAppsConfig(
+            apps={
+                "demo1": {
+                    "uuid": "DEMO-APP",
+                    "image": "demofact/demo1",
+                    "image_pull_policy": "missing"
+                }
+            }
+        )
+
+        self.assertEqual(config.apps["demo1"].image_pull_policy, "missing")
+
+    def test_invalid_image_pull_policy(self):
+        """ invalid image_pull_policy should raise ValidationError """
+
+        with self.assertRaises(ValidationError) as cm:
+            OpenFactoryAppsConfig(
+                apps={
+                    "demo1": {
+                        "uuid": "DEMO-APP",
+                        "image": "demofact/demo1",
+                        "image_pull_policy": "sometimes"
+                    }
+                }
+            )
+
+        errors = cm.exception.errors()
+
+        self.assertTrue(
+            any(
+                e["loc"] == ("apps", "demo1", "image_pull_policy")
+                for e in errors
+            )
+        )
+
+    @patch("openfactory.schemas.apps.load_yaml")
+    def test_image_pull_policy_integration_with_get_apps_from_config_file(self, mock_load_yaml):
+        """ image_pull_policy is correctly parsed and attached using get_apps_from_config_file """
+        mock_load_yaml.return_value = {
+            "apps": {
+                "demo1": {
+                    "uuid": "DEMO-APP",
+                    "uns": {"workcenter": "WC2"},
+                    "image": "demofact/demo1",
+                    "image_pull_policy": "always"
+                }
+            }
+        }
+
+        result = get_apps_from_config_file("dummy.yaml", self.uns_schema)
+
+        self.assertEqual(result["demo1"].image_pull_policy, "always")
+
     def test_missing_apps_key(self):
         """ Test missing `apps` key"""
         invalid_config = {


### PR DESCRIPTION
# Add image_pull_policy to OpenFactory App schema

## Summary

This PR adds support for the `image_pull_policy` field in the OpenFactory App schema.

The new field allows application definitions to declare the desired image pull behavior during deployment.

Supported values are:

* `missing` (default)
* `always`

## Changes

### Schema

Added:

```python
ImagePullPolicy = Literal["missing", "always"]
```

and the new field:

```python
image_pull_policy: ImagePullPolicy = Field(
    default="missing",
    description=(
        "Image pull policy. "
        "'missing' pulls only if the image is absent locally. "
        "'always' always pulls before deployment."
    )
)
```

### Validation

Added schema validation for:

* default value (`missing`)
* explicit `missing`
* explicit `always`
* invalid values

### Documentation

Updated:

* OpenFactory App schema documentation
* Application Definition documentation
* YAML examples

## Backward Compatibility

This change is fully backward compatible.

Existing application definitions continue to work unchanged because `image_pull_policy` defaults to `missing`.

## Scope

This PR only introduces the schema field, validation, tests, and documentation.

Deployment behavior associated with `image_pull_policy` is intentionally out of scope and will be implemented in a follow-up PR.
