### PR TITLE
Add image_pull_policy support to OpenFactory deployments

### DIFF
--- a/openfactory/openfactory_deploy_strategy.py
+++ b/openfactory/openfactory_deploy_strategy.py
@@ -17,6 +17,7 @@ Key Components:
 Features:
 ---------
 - Unified interface for deploying and removing OpenFactory services.
+- Supports configurable image pull policies (``missing`` and ``always``).
 - Supports optional runtime UID/GID configuration for compatibility with shared
   filesystems such as NFS.
 - Supports environment variables, container commands, labels, ports, networks,
@@ -33,6 +34,7 @@ Usage Example:
     local_strategy = LocalDockerDeploymentStrategy()
     local_strategy.deploy(
         image="ghcr.io/openfactoryio/scheduler:v1.0.0",
+        image_pull_policy="missing",
         name="scheduler",
         user="1234:5678",
         env=["ENV=production"],
@@ -48,6 +50,7 @@ Usage Example:
     swarm_strategy = SwarmDeploymentStrategy()
     swarm_strategy.deploy(
         image="ghcr.io/openfactoryio/reporter:v1.0.0",
+        image_pull_policy="missing",
         name="reporter",
         user="1234:5678",
         env=["LOG_LEVEL=info"],
@@ -69,8 +72,11 @@ to standardize service deployment across local development and production enviro
 import docker
 from docker.types import Mount, DriverConfig
 from abc import ABC, abstractmethod
-from typing import List, Dict, Optional, Any
+from typing import List, Dict, Optional, Any, Literal
 from openfactory.docker.docker_access_layer import dal
+
+
+ImagePullPolicy = Literal["missing", "always"]
 
 
 class OpenFactoryServiceDeploymentStrategy(ABC):
@@ -79,6 +85,7 @@ class OpenFactoryServiceDeploymentStrategy(ABC):
     @abstractmethod
     def deploy(self, *,
                image: str,
+               image_pull_policy: ImagePullPolicy = "missing",
                user: Optional[str] = None,
                name: str,
                env: List[str],
@@ -95,6 +102,10 @@ class OpenFactoryServiceDeploymentStrategy(ABC):
 
         Args:
             image (str): Docker image to deploy.
+            image_pull_policy (str): Image pull behavior.
+
+                - ``missing``: Pull the image only if it is not available locally.
+                - ``always``: Always pull the image before deployment.
             user (Optional[str]): Runtime user in Docker format ``UID:GID``.
             name (str): Name of the service or container.
             env (List[str]): Environment variables in `KEY=VALUE` format.
@@ -125,6 +136,7 @@ class SwarmDeploymentStrategy(OpenFactoryServiceDeploymentStrategy):
 
     def deploy(self, *,
                image: str,
+               image_pull_policy: ImagePullPolicy = "missing",
                user: Optional[str] = None,
                name: str,
                env: List[str],
@@ -140,6 +152,9 @@ class SwarmDeploymentStrategy(OpenFactoryServiceDeploymentStrategy):
         Deploy a Docker service using Docker Swarm.
 
         See parent method for argument descriptions.
+
+        Note:
+            - ``image_pull_policy`` is currently ignored for Swarm deployments.
         """
         dal.docker_client.services.create(
             image=image,
@@ -206,6 +221,7 @@ class LocalDockerDeploymentStrategy(OpenFactoryServiceDeploymentStrategy):
 
     def deploy(self, *,
                image: str,
+               image_pull_policy: ImagePullPolicy = "missing",
                user: Optional[str] = None,
                name: str,
                env: List[str],
@@ -224,6 +240,7 @@ class LocalDockerDeploymentStrategy(OpenFactoryServiceDeploymentStrategy):
 
         Note:
             - ``constraints`` and ``mode`` are ignored for local containers.
+            - ``image_pull_policy="always"`` forces a Docker image pull before deployment.
         """
         client = docker.from_env()
 
@@ -240,6 +257,9 @@ class LocalDockerDeploymentStrategy(OpenFactoryServiceDeploymentStrategy):
                     docker_mounts.append(self.swarm_mount_to_container_mount(m))
                 else:
                     raise ValueError(f"Unsupported mount type: {m['Type']}")
+
+        if image_pull_policy == "always":
+            client.images.pull(image)
 
         container = client.containers.run(
             image=image,

--- a/openfactory/openfactory_manager.py
+++ b/openfactory/openfactory_manager.py
@@ -188,6 +188,9 @@ class OpenFactoryManager(OpenFactory):
         """
         Deploy an OpenFactory application.
 
+        The application image and image pull policy are forwarded to the
+        configured deployment strategy.
+
         Args:
             application (OpenFactoryAppSchema): The application configuration.
 
@@ -274,6 +277,7 @@ class OpenFactoryManager(OpenFactory):
         try:
             self.deployment_strategy.deploy(
                 image=application.image,
+                image_pull_policy=application.image_pull_policy,
                 user=runtime_user,
                 name=application.uuid.lower(),
                 mode={"Replicated": {"Replicas": 1}},

--- a/tests/openfactory/test_openfactory_deploy_strategy.py
+++ b/tests/openfactory/test_openfactory_deploy_strategy.py
@@ -42,6 +42,21 @@ class TestSwarmDeploymentStrategy(unittest.TestCase):
         self.assertEqual(kwargs["mode"], {"Replicated": {"Replicas": 2}})
 
     @patch("openfactory.openfactory_deploy_strategy.dal.docker_client")
+    def test_swarm_deploy_accepts_image_pull_policy(self, mock_docker_client):
+        """ Test Docker Swarm deploy accepts image_pull_policy parameter """
+
+        strategy = SwarmDeploymentStrategy()
+
+        strategy.deploy(
+            image="test-image",
+            image_pull_policy="always",
+            name="test-service",
+            env=["ENV=prod"]
+        )
+
+        mock_docker_client.services.create.assert_called_once()
+
+    @patch("openfactory.openfactory_deploy_strategy.dal.docker_client")
     def test_swarm_deploy_with_runtime_user(self, mock_docker_client):
         """ Test Docker Swarm deploy with runtime user """
 
@@ -150,6 +165,44 @@ class TestLocalDockerDeploymentStrategy(unittest.TestCase):
         self.assertEqual(kwargs["network"], "bridge")
         self.assertEqual(kwargs["labels"], {"type": "api"})
         self.assertEqual(kwargs["nano_cpus"], 1000000000)
+
+    @patch("openfactory.openfactory_deploy_strategy.docker.from_env")
+    def test_local_deploy_image_pull_policy_always(self, mock_from_env):
+        """ Test local Docker deploy always pulls image before deployment """
+
+        mock_client = MagicMock()
+        mock_from_env.return_value = mock_client
+
+        strategy = LocalDockerDeploymentStrategy()
+
+        strategy.deploy(
+            image="test-image",
+            image_pull_policy="always",
+            name="test-container",
+            env=["ENV=dev"]
+        )
+
+        mock_client.images.pull.assert_called_once_with("test-image")
+        mock_client.containers.run.assert_called_once()
+
+    @patch("openfactory.openfactory_deploy_strategy.docker.from_env")
+    def test_local_deploy_image_pull_policy_missing(self, mock_from_env):
+        """ Test local Docker deploy does not explicitly pull image when policy is missing """
+
+        mock_client = MagicMock()
+        mock_from_env.return_value = mock_client
+
+        strategy = LocalDockerDeploymentStrategy()
+
+        strategy.deploy(
+            image="test-image",
+            image_pull_policy="missing",
+            name="test-container",
+            env=["ENV=dev"]
+        )
+
+        mock_client.images.pull.assert_not_called()
+        mock_client.containers.run.assert_called_once()
 
     @patch("openfactory.openfactory_deploy_strategy.docker.from_env")
     def test_local_deploy_with_runtime_user(self, mock_from_env):

--- a/tests/openfactory/test_openfactorymanager.py
+++ b/tests/openfactory/test_openfactorymanager.py
@@ -455,6 +455,25 @@ class TestOpenFactoryManager(unittest.TestCase):
 
     @patch("openfactory.openfactory_manager.register_asset")
     @patch("openfactory.openfactory_manager.user_notify")
+    def test_deploy_openfactory_application_passes_image_pull_policy(self, mock_user_notify, mock_register_asset):
+        """ image_pull_policy should be passed to deployment strategy """
+
+        app = OpenFactoryAppSchema(
+            uuid="APP_PULL_POLICY",
+            image="app_image",
+            image_pull_policy="always"
+        )
+
+        self.manager.deploy_openfactory_application(app)
+
+        deploy_call = self.manager.deployment_strategy.deploy.call_args
+        kwargs = deploy_call.kwargs
+
+        self.assertIn("image_pull_policy", kwargs)
+        self.assertEqual(kwargs["image_pull_policy"], "always")
+
+    @patch("openfactory.openfactory_manager.register_asset")
+    @patch("openfactory.openfactory_manager.user_notify")
     def test_deploy_openfactory_application_runtime_user(self, mock_user_notify, mock_register_asset):
         """ runtime UID/GID should be passed to deployment strategy """
         app = OpenFactoryAppSchema(


### PR DESCRIPTION
# Add image_pull_policy support to OpenFactory deployments

## Summary

This PR adds support for `image_pull_policy` to OpenFactory applications and propagates the configuration through the deployment stack.

Supported values are:

* `missing` (default)
* `always`

For local Docker deployments, `always` forces a Docker image pull before container creation.

## Changes

### Application Schema

Added a new optional field:

```yaml
apps:
  opcua-gateway:
    image: ghcr.io/openfactoryio/opcua-gateway:latest
    image_pull_policy: always
```

Supported values:

* `missing`
* `always`

Default:

```yaml
image_pull_policy: missing
```

### Deployment API

Extended deployment strategy interfaces to accept:

```python
image_pull_policy: ImagePullPolicy
```

This parameter is now propagated through the deployment stack.

### OpenFactory Manager

`deploy_openfactory_application()` now forwards the configured image pull policy to the selected deployment strategy.

### Local Docker Deployment

Implemented support for:

```python
if image_pull_policy == "always":
    client.images.pull(image)
```

before container creation.

For `missing`, Docker's default image handling behavior is used.

### Docker Swarm Deployment

The parameter is accepted by the Swarm deployment strategy interface.

No Swarm-specific behavior is currently implemented.

### Documentation

Updated:

* Deployment strategy API documentation
* Application Definition documentation
* OpenFactory App schema documentation
* YAML examples

### Tests

Added tests covering:

* schema validation
* default value handling
* explicit `missing`
* explicit `always`
* invalid values
* propagation through `get_apps_from_config_file()`
* propagation through `deploy_openfactory_application()`
* local deployment behavior

## Example

```yaml
apps:
  opcua-gateway:
    image: ghcr.io/openfactoryio/opcua-gateway:latest
    image_pull_policy: always
```

This ensures that the latest image available in the registry is checked and pulled before deployment.

## Backward Compatibility

This change is fully backward compatible.

Existing application definitions continue to work unchanged because `image_pull_policy` defaults to `missing`.
