### PR TITLE
Add Prometheus metrics registration support to OpenFactory applications

### DIFF
--- a/openfactory/apps/ofaapp.py
+++ b/openfactory/apps/ofaapp.py
@@ -9,12 +9,14 @@ from types import FrameType
 from typing import Optional
 from pydantic import TypeAdapter
 from openfactory import __version__
+from openfactory.exceptions import OFAException
 from openfactory.kafka import KSQLDBClient
 from openfactory.utils.assets import deregister_asset
 from openfactory.assets import Asset, AssetAttribute
 from openfactory.setup_logging import configure_prefixed_logger
 from openfactory.schemas.filelayer.storage import StorageBackendSchema
 from openfactory.schemas.command_header import CommandEnvelope
+from openfactory.monitoring.utils import discover_prometheus_registry
 from openfactory.filelayer.backend import FileBackend
 from openfactory.apps.attributefield import OpenFactoryAppMeta, EventAttribute
 
@@ -318,6 +320,30 @@ class OpenFactoryApp(Asset, metaclass=OpenFactoryAppMeta):
         print(f"Application manufacturer:    {self.application_manufacturer.value}")
         print(f"Application license:         {self.application_license.value}")
         print("==============================================================")
+
+    def register_prometheus_metrics(self, metrics_port: int, metrics_path: str = '/metrics') -> None:
+        """
+        Register Prometheus metrics with the OpenFactory Prometheus metrics registry
+
+        Args:
+            metrics_port (int): Port on which metrics is published
+            metrics_path (str): Endpoint of metrics. Defaults to ``/metrics``
+        """
+        try:
+            registry_uuid = discover_prometheus_registry(self.ksql)
+        except OFAException:
+            self.logger.warning("No OpenFactory Prometheus metrics registry deployed - Metrics not registerd")
+            return
+        self.logger.debug(f"Registering metrics with OpenFactory Prometheus metrics registry {registry_uuid}")
+        registry = Asset(registry_uuid, ksqlClient=self.ksql, bootstrap_servers=self.bootstrap_servers)
+        registry.method('register_target', 'ofa-cli',
+                        args=[
+                            ('application_uuid', self.asset_uuid),
+                            ('host', self.asset_uuid.lower()),
+                            ('port', str(metrics_port)),
+                            ('path', metrics_path),
+                            ])
+        registry.close()
 
     def app_event_loop_stopped(self) -> None:
         """ Called when main loop is stopped. """

--- a/tests/openfactory/apps/test_openfactoryapp.py
+++ b/tests/openfactory/apps/test_openfactoryapp.py
@@ -474,3 +474,61 @@ class TestOpenFactoryAppAsync(unittest.IsolatedAsyncioTestCase):
         await app.async_run()
 
         app.shutdown.assert_called_once()
+
+    @patch("openfactory.apps.ofaapp.Asset")
+    @patch("openfactory.apps.ofaapp.discover_prometheus_registry")
+    def test_register_prometheus_metrics_success(self, mock_discover_registry, MockAsset):
+        """ Metrics registry is discovered and target is registered. """
+
+        mock_discover_registry.return_value = "PROM-UUID"
+        mock_registry = MagicMock()
+        MockAsset.return_value = mock_registry
+
+        app = OpenFactoryApp(
+            ksqlClient=self.ksql_mock,
+            bootstrap_servers="mock_bootstrap",
+            asset_router_url="mocked_asset_url"
+        )
+
+        app.register_prometheus_metrics(metrics_port=8000, metrics_path="/metrics")
+
+        mock_discover_registry.assert_called_once_with(self.ksql_mock)
+
+        MockAsset.assert_called_once_with(
+            "PROM-UUID",
+            ksqlClient=self.ksql_mock,
+            bootstrap_servers="mock_bootstrap"
+        )
+
+        mock_registry.method.assert_called_once_with(
+            "register_target",
+            "ofa-cli",
+            args=[
+                ("application_uuid", "DEV-UUID"),
+                ("host", "dev-uuid"),
+                ("port", "8000"),
+                ("path", "/metrics"),
+            ]
+        )
+
+        mock_registry.close.assert_called_once()
+
+    @patch("openfactory.apps.ofaapp.discover_prometheus_registry")
+    def test_register_prometheus_metrics_no_registry(self, mock_discover_registry):
+        """ No Prometheus registry deployed. """
+
+        mock_discover_registry.side_effect = OFAException("not found")
+
+        app = OpenFactoryApp(
+            ksqlClient=self.ksql_mock,
+            bootstrap_servers="mock_bootstrap",
+            asset_router_url="mocked_asset_url"
+        )
+
+        app.logger = MagicMock()
+        app.register_prometheus_metrics(metrics_port=8000)
+
+        mock_discover_registry.assert_called_once_with(self.ksql_mock)
+        app.logger.warning.assert_called_once_with(
+            "No OpenFactory Prometheus metrics registry deployed - Metrics not registerd"
+        )


### PR DESCRIPTION
## Add Prometheus metrics registration support to OpenFactory applications

### Summary

This PR introduces a new `register_prometheus_metrics()` method on `OpenFactoryApp` that allows applications exposing Prometheus metrics to register themselves with the OpenFactory Prometheus metrics registry.

The method automatically discovers the deployed Prometheus registry asset and registers the application's metrics endpoint as a scrape target. If no registry is deployed, registration is skipped gracefully and a warning is logged.

### Motivation

Applications exposing Prometheus metrics currently require manual configuration to become discoverable by the OpenFactory monitoring stack.

This change provides a simple API for applications to register their metrics endpoints and enables automatic integration with the OpenFactory Prometheus registry.

### Example

```python
app.register_prometheus_metrics(
    metrics_port=8000
)
```

Custom metrics path:

```python
app.register_prometheus_metrics(
    metrics_port=8000,
    metrics_path="/custom-metrics"
)
```

### Implementation Details

* Added `OpenFactoryApp.register_prometheus_metrics()`.
* Automatically discovers the Prometheus registry using `discover_prometheus_registry()`.
* Registers the application using the registry asset's `register_target` method.
* Uses:

  * application UUID as target identifier
  * application UUID (lowercase) as target host
  * configurable port
  * configurable metrics path
* Handles missing registry deployments gracefully by catching `OFAException`.
* Closes the registry asset after registration.

### Example Registration Payload

```python
[
    ("application_uuid", self.asset_uuid),
    ("host", self.asset_uuid.lower()),
    ("port", str(metrics_port)),
    ("path", metrics_path),
]
```

### Backward Compatibility

This change is fully backward compatible.

* Existing applications are unaffected.
* Registration is only performed when explicitly invoked.
* Applications running in environments without a Prometheus registry continue to operate normally.

### Testing

* Verified successful registration against a discovered registry.
* Verified graceful handling when no Prometheus registry is deployed.
* Verified correct registration arguments are passed to `register_target`.
* Verified registry asset cleanup after registration.
