### PR TITLE
Handle Fatal Kafka Consumer Errors

### DIFF
--- a/openfactory/fanoutlayer/asset_forwarder/src/asset_forwarder_service.py
+++ b/openfactory/fanoutlayer/asset_forwarder/src/asset_forwarder_service.py
@@ -388,13 +388,26 @@ class AssetForwarderService(OpenFactoryFastAPIApp):
                 if msg.error():
                     if msg.error().code() == KafkaError._PARTITION_EOF:
                         continue
-                    self.logger.error("Kafka error: %s", msg.error())
+                    err = msg.error()
+                    self.logger.error(
+                        "Kafka error: code=%s name=%s fatal=%s retriable=%s message=%s",
+                        err.code(),
+                        err.name(),
+                        err.fatal(),
+                        err.retriable(),
+                        err,
+                    )
                     forwarder_metrics.KAFKA_ERRORS.labels(forwarder=self.asset_uuid).inc()
+
+                    if err.fatal():
+                        self.logger.critical("Fatal Kafka error: %s (name=%s)", err, err.name())
+                        os._exit(1)
+
                     continue
 
                 value = self.decode_message_value(msg.value())
                 value = self.add_timestamps(value, msg)
-                self.logger.debug(f"Main id={id(msg)}   partition={msg.partition()} offset={msg.offset()} key={msg.key()} {value['ID']}")
+                self.logger.debug(f"Main id={id(msg)}   partition={msg.partition()} offset={msg.offset()} key={msg.key()} {value.get("ID")}")
                 await self.queue.put({
                     "msg": msg,
                     "value": value,

--- a/tests/openfactory/fanoutlayer/asset_forwarder/test_asset_forwarder_service_main_loop.py
+++ b/tests/openfactory/fanoutlayer/asset_forwarder/test_asset_forwarder_service_main_loop.py
@@ -1,0 +1,167 @@
+import asyncio
+import unittest
+from unittest.mock import AsyncMock, MagicMock, patch
+from confluent_kafka import KafkaError
+from openfactory.fanoutlayer.asset_forwarder.src.asset_forwarder_service import AssetForwarderService
+
+
+class TestAssetForwarderMainLoop(unittest.IsolatedAsyncioTestCase):
+    """
+    Unit tests for AssetForwarderService async main loop.
+    """
+
+    def setUp(self):
+        """ Create a service instance configured for main loop testing. """
+        self.service = AssetForwarderService(
+            ksqlClient=MagicMock(),
+            bootstrap_servers="localhost:9092",
+            test_mode=True,
+        )
+
+        self.service.logger = MagicMock()
+        self.service.consumer = MagicMock()
+        self.service.queue = asyncio.Queue()
+
+    async def test_async_main_loop_subscribes_consumer(self):
+        """ Test Kafka consumer subscription is configured. """
+
+        self.service.worker = AsyncMock()
+        self.service.consumer.consume.side_effect = asyncio.CancelledError()
+
+        with self.assertRaises(asyncio.CancelledError):
+            await self.service.async_main_loop()
+
+        self.service.consumer.subscribe.assert_called_once_with(
+            [self.service.kafka_topic],
+            on_assign=self.service._on_assign,
+            on_revoke=self.service._on_revoke,
+        )
+
+    @patch("openfactory.fanoutlayer.asset_forwarder.src.asset_forwarder_service.forwarder_metrics")
+    async def test_async_main_loop_queues_valid_message(self, mock_metrics):
+        """ Test valid Kafka messages are queued. """
+
+        msg = MagicMock()
+        msg.error.return_value = None
+        msg.value.return_value = b'{"ID":"123"}'
+
+        self.service.worker = AsyncMock()
+        self.service.decode_message_value = MagicMock(return_value={"ID": "123"})
+        self.service.add_timestamps = MagicMock(return_value={"ID": "123"})
+        self.service.consumer.consume.side_effect = [
+            [msg],
+            asyncio.CancelledError(),
+        ]
+
+        with self.assertRaises(asyncio.CancelledError):
+            await self.service.async_main_loop()
+
+        item = self.service.queue.get_nowait()
+
+        self.assertEqual(item["msg"], msg)
+        self.assertEqual(item["value"]["ID"], "123")
+        mock_metrics.KAFKA_MESSAGES_CONSUMED.labels.assert_called_once_with(forwarder=self.service.asset_uuid)
+        mock_metrics.KAFKA_MESSAGES_CONSUMED.labels.return_value.inc.assert_called_once()
+
+    @patch("openfactory.fanoutlayer.asset_forwarder.src.asset_forwarder_service.forwarder_metrics")
+    async def test_async_main_loop_updates_queue_size_metric(self, mock_metrics):
+        """ Test queue size gauge is updated when message is queued. """
+
+        msg = MagicMock()
+        msg.error.return_value = None
+        msg.value.return_value = b'{"ID":"123"}'
+
+        self.service.worker = AsyncMock()
+
+        self.service.decode_message_value = MagicMock(return_value={"ID": "123"})
+        self.service.add_timestamps = MagicMock(return_value={"ID": "123"})
+        self.service.consumer.consume.side_effect = [
+            [msg],
+            asyncio.CancelledError(),
+        ]
+
+        with self.assertRaises(asyncio.CancelledError):
+            await self.service.async_main_loop()
+
+        mock_metrics.QUEUE_SIZE.labels.assert_called_once_with(forwarder=self.service.asset_uuid)
+        mock_metrics.QUEUE_SIZE.labels.return_value.set.assert_called_once()
+
+    @patch("openfactory.fanoutlayer.asset_forwarder.src.asset_forwarder_service.forwarder_metrics")
+    async def test_async_main_loop_ignores_partition_eof(self, mock_metrics):
+        """ Test partition EOF messages are ignored. """
+
+        err = MagicMock()
+        err.code.return_value = KafkaError._PARTITION_EOF
+        msg = MagicMock()
+        msg.error.return_value = err
+        self.service.worker = AsyncMock()
+        self.service.consumer.consume.side_effect = [
+            [msg],
+            asyncio.CancelledError(),
+        ]
+
+        with self.assertRaises(asyncio.CancelledError):
+            await self.service.async_main_loop()
+
+        self.assertTrue(self.service.queue.empty())
+        mock_metrics.KAFKA_ERRORS.labels.return_value.inc.assert_not_called()
+
+    @patch("openfactory.fanoutlayer.asset_forwarder.src.asset_forwarder_service.forwarder_metrics")
+    async def test_async_main_loop_increments_kafka_error_metric(self, mock_metrics):
+        """ Test Kafka errors increment Prometheus metrics. """
+        err = MagicMock()
+        err.code.return_value = KafkaError._UNKNOWN_PARTITION
+        err.name.return_value = "UNKNOWN_PARTITION"
+        err.fatal.return_value = False
+        err.retriable.return_value = True
+
+        msg = MagicMock()
+        msg.error.return_value = err
+
+        self.service.worker = AsyncMock()
+        self.service.consumer.consume.side_effect = [
+            [msg],
+            asyncio.CancelledError(),
+        ]
+
+        with self.assertRaises(asyncio.CancelledError):
+            await self.service.async_main_loop()
+
+        mock_metrics.KAFKA_ERRORS.labels.assert_called_once_with(forwarder=self.service.asset_uuid)
+        mock_metrics.KAFKA_ERRORS.labels.return_value.inc.assert_called_once()
+
+    @patch("openfactory.fanoutlayer.asset_forwarder.src.asset_forwarder_service.os._exit")
+    @patch("openfactory.fanoutlayer.asset_forwarder.src.asset_forwarder_service.forwarder_metrics")
+    async def test_async_main_loop_exits_on_fatal_kafka_error(self, mock_metrics, mock_exit):
+        """ Test fatal Kafka errors terminate the process. """
+
+        err = MagicMock()
+        err.code.return_value = -1
+        err.name.return_value = "FATAL_ERROR"
+        err.fatal.return_value = True
+        err.retriable.return_value = False
+
+        msg = MagicMock()
+        msg.error.return_value = err
+
+        self.service.worker = AsyncMock()
+        self.service.consumer.consume.side_effect = [
+            [msg],
+            asyncio.CancelledError(),
+        ]
+
+        with self.assertRaises(asyncio.CancelledError):
+            await self.service.async_main_loop()
+
+        mock_metrics.KAFKA_ERRORS.labels.return_value.inc.assert_called_once()
+        mock_exit.assert_called_once_with(1)
+
+    @patch("openfactory.fanoutlayer.asset_forwarder.src.asset_forwarder_service.asyncio.create_task")
+    async def test_async_main_loop_starts_worker(self, mock_create_task):
+        """ Test worker task is started when main loop starts. """
+        self.service.consumer.consume.side_effect = asyncio.CancelledError()
+
+        with self.assertRaises(asyncio.CancelledError):
+            await self.service.async_main_loop()
+
+        mock_create_task.assert_called_once()


### PR DESCRIPTION
# Handle Fatal Kafka Consumer Errors

## Summary

Improve Kafka error handling in the Asset Forwarder by distinguishing between recoverable and fatal Kafka consumer errors.

The Asset Forwarder now logs detailed Kafka error information and terminates the process when Kafka reports a fatal consumer error, allowing the orchestration platform to restart the service and create a fresh consumer instance.

## Changes

### Improved Kafka Error Logging

Kafka error logs now include additional diagnostic information:

* Error code
* Error name
* Fatal status
* Retriable status
* Error message

Example:

```python
Kafka error: code=%s name=%s fatal=%s retriable=%s message=%s
```

This provides significantly better operational visibility when troubleshooting Kafka consumer issues.

### Fatal Kafka Error Handling

Added explicit handling of fatal Kafka errors:

* Detect Kafka errors using `err.fatal()`
* Log a critical error
* Terminate the process using `os._exit(1)`

This allows Docker, Kubernetes, Nomad, or other orchestrators to restart the service and create a new Kafka consumer.

### Test Coverage

Added unit test coverage verifying that:

* Fatal Kafka errors are detected correctly.
* The Asset Forwarder exits with status code 1 when a fatal Kafka error is encountered.

## Motivation

Previously, all Kafka errors were treated identically and the service continued processing regardless of severity.

Fatal Kafka errors indicate that the current consumer instance may no longer be recoverable. Restarting the process is safer than continuing operation with a potentially invalid consumer state.

This behavior aligns with the existing strategy used elsewhere in the Asset Forwarder for unrecoverable failures.
