### PR TITLE
Add support for file descriptor limits in deployment schema

### DIFF
--- a/docs/guide/applications/definition.rst
+++ b/docs/guide/applications/definition.rst
@@ -196,7 +196,9 @@ All networks must exist prior to deployment.
 Deployment
 ----------
 
-The ``deploy`` section defines how the application is deployed.
+The ``deploy`` section defines how the application is deployed,
+including replicas, resource limits, file descriptor limits,
+and placement constraints.
 
 .. code-block:: yaml
 
@@ -210,6 +212,7 @@ The ``deploy`` section defines how the application is deployed.
         limits:
           cpus: 1.0
           memory: "1Gi"
+          open_files: 65535
 
       placement:
         constraints:
@@ -261,6 +264,7 @@ The ``deploy`` section defines how the application is deployed.
                 limits:
                   cpus: 1.0
                   memory: "1Gi"
+                  open_files: 65535
 
               placement:
                 constraints:
@@ -276,3 +280,34 @@ The ``deploy`` section defines how the application is deployed.
 .. seealso::
     - The schema of OpenFactory Apps is :class:`openfactory.schemas.apps.OpenFactoryAppSchema`.
     - The runtime class of OpenFactory Apps is :class:`openfactory.apps.ofaapp.OpenFactoryApp`.
+
+Open File Descriptors
+~~~~~~~~~~~~~~~~~~~~~
+
+Applications that manage large numbers of devices or network connections
+may require more file descriptors than the default container limit.
+
+The ``open_files`` setting defines the maximum number of Linux file
+descriptors available to the application.
+
+.. code-block:: yaml
+
+    deploy:
+      resources:
+        limits:
+          open_files: 65535
+
+Linux file descriptors include:
+
+- files
+- network sockets
+- pipes
+- event polling descriptors
+- other operating-system resources
+
+Applications managing many devices or network connections may require a
+higher limit than the platform default.
+
+If ``open_files`` is not specified, OpenFactory does not define a file
+descriptor limit and the default limit provided by the container runtime
+(e.g., Docker Engine) is used.

--- a/openfactory/schemas/apps.py
+++ b/openfactory/schemas/apps.py
@@ -101,6 +101,7 @@ configuration YAML file, with automatic UNS enrichment.
               limits:
                 cpus: 1.0
                 memory: "1Gi"
+                open_files: 65535
 
             placement:
                 constraints:

--- a/openfactory/schemas/common.py
+++ b/openfactory/schemas/common.py
@@ -7,14 +7,14 @@ to be shared across device and connector configuration schemas.
 
 Components:
 -----------
-- `ResourcesDefinition`: Represents CPU and memory values for a container.
+- `ResourcesDefinition`: Represents CPU, memory, and file descriptor limits for a container.
 - `Resources`: Groups `reservations` and `limits` for container resources.
 - `Placement`: Defines constraints for container placement on specific nodes.
 - `Deploy`: Complete deployment configuration including replicas, resource configs, and placement rules.
 
 Key Features:
 -------------
-- Express CPU and memory constraints using common formats (e.g., 0.5 CPUs, "1Gi" memory)
+- Express CPU, memory, and file descriptor constraints for containers
 - Define both resource requests and limits for containers
 - Support placement constraints for scheduling on labeled nodes
 - Modular, reusable across multiple OpenFactory schema modules
@@ -26,7 +26,7 @@ Define a deployment configuration:
     >>> Deploy(
     ...     replicas=2,
     ...     resources=Resources(
-    ...         reservations=ResourcesDefinition(cpus=0.5, memory="512Mi"),
+    ...         reservations=ResourcesDefinition(cpus=0.5, memory="512Mi", open_files=65535),
     ...         limits=ResourcesDefinition(cpus=1.0, memory="1Gi")
     ...     ),
     ...     placement=Placement(
@@ -44,14 +44,27 @@ from typing import List, Optional, Dict, Any
 
 
 class ResourcesDefinition(BaseModel):
-    """ Defines resource limits or reservations such as CPU and memory. """
+    """ Defines resource limits or reservations such as CPU, memory, and open file descriptors. """
+
     cpus: Optional[float] = Field(
         default=None,
         description="Amount of CPU to allocate, expressed as a fractional number (e.g., 0.25 = one quarter of a CPU core)."
     )
+
     memory: Optional[str] = Field(
         default=None,
         description="Amount of memory to allocate (e.g., '512Mi', '1Gi')."
+    )
+
+    open_files: Optional[int] = Field(
+        default=None,
+        ge=1,
+        description=(
+            "Maximum number of Linux file descriptors available to the container. "
+            "File descriptors include files, network sockets, pipes, and other "
+            "operating-system resources. Applications managing many devices or "
+            "network connections may require a higher limit than the default value."
+        )
     )
 
 
@@ -187,8 +200,8 @@ def resources(deploy: Optional[Deploy]) -> Optional[Dict[str, Dict[str, Any]]]:
     """
     Retrieve and normalize resources from a Deploy object for Docker deployments.
 
-    Extracts CPU and memory settings from ``deploy.resources`` and converts them
-    into the dictionary format expected by Docker.
+    Extracts CPU, memory, and file descriptor settings from ``deploy.resources``
+    and converts them into the dictionary format expected by Docker.
 
     Args:
         deploy (Optional[Deploy]): Deployment configuration for an application.
@@ -271,3 +284,23 @@ def constraints(deploy: Optional[Deploy]) -> Optional[List[str]]:
         normalized.append(c.strip())
 
     return normalized
+
+
+def open_files_limit(deploy: Optional[Deploy], default: Optional[int] = None) -> Optional[int]:
+    """
+    Retrieve the open file descriptor limit value from a Deploy object.
+
+    Args:
+        deploy (Optional[Deploy]): The deployment configuration object.
+        default (Optional[int]): Value returned if no limit is configured.
+
+    Returns:
+        Optional[int]: Configured open file descriptor limit or default.
+    """
+    if deploy is None:
+        return default
+
+    resources = getattr(deploy, 'resources', None)
+    limits = resources.limits if resources else None
+
+    return limits.open_files if limits and limits.open_files is not None else default

--- a/tests/openfactory/schemas/test_common.py
+++ b/tests/openfactory/schemas/test_common.py
@@ -26,6 +26,16 @@ class TestCommonSchemas(unittest.TestCase):
         with self.assertRaises(ValidationError):
             ResourcesDefinition(cpus="not-a-float")
 
+    def test_resources_definition_open_files(self):
+        """ Test ResourcesDefinition with open_files. """
+        model = ResourcesDefinition(open_files=65535)
+        self.assertEqual(model.open_files, 65535)
+
+    def test_resources_definition_invalid_open_files(self):
+        """ Test ResourcesDefinition rejects invalid open_files values. """
+        with self.assertRaises(ValidationError):
+            ResourcesDefinition(open_files=0)
+
     def test_resources_valid(self):
         """ Test valid Resources with nested reservations and limits. """
         data = {
@@ -65,16 +75,26 @@ class TestCommonSchemas(unittest.TestCase):
         data = {
             "replicas": 3,
             "resources": {
-                "reservations": {"cpus": 0.2, "memory": "128Mi"},
-                "limits": {"cpus": 0.5, "memory": "256Mi"}
+                "reservations": {
+                    "cpus": 0.2,
+                    "memory": "128Mi"
+                },
+                "limits": {
+                    "cpus": 0.5,
+                    "memory": "256Mi",
+                    "open_files": 65535
+                }
             },
             "placement": {
                 "constraints": ["node.labels.arch == amd64"]
             }
         }
+
         model = Deploy(**data)
+
         self.assertEqual(model.replicas, 3)
         self.assertEqual(model.resources.limits.cpus, 0.5)
+        self.assertEqual(model.resources.limits.open_files, 65535)
         self.assertEqual(model.placement.constraints[0], "node.labels.arch == amd64")
 
     def test_deploy_invalid_replicas(self):

--- a/tests/openfactory/schemas/test_open_files.py
+++ b/tests/openfactory/schemas/test_open_files.py
@@ -1,0 +1,45 @@
+import unittest
+from openfactory.schemas.common import open_files_limit, Deploy, Resources, ResourcesDefinition
+
+
+class TestOpenFilesLimit(unittest.TestCase):
+    """
+    Test class for the open_files_limit function
+    """
+
+    def test_none_deploy_returns_default(self):
+        """ Test that None deploy returns the default value """
+        self.assertEqual(open_files_limit(None), None)
+        self.assertEqual(open_files_limit(None, default=65535), 65535)
+
+    def test_deploy_without_resources_returns_default(self):
+        """ Test deploy with no resources returns the default """
+        deploy = Deploy(resources=None)
+        self.assertEqual(open_files_limit(deploy), None)
+
+    def test_deploy_with_resources_without_limits_returns_default(self):
+        """ Test deploy with resources but no limits returns the default """
+        resources = Resources(reservations=None, limits=None)
+        deploy = Deploy(resources=resources)
+        self.assertEqual(open_files_limit(deploy), None)
+
+    def test_deploy_with_limits_without_open_files_returns_default(self):
+        """ Test deploy with limits but open_files is None returns the default """
+        limits = ResourcesDefinition(open_files=None)
+        resources = Resources(reservations=None, limits=limits)
+        deploy = Deploy(resources=resources)
+        self.assertEqual(open_files_limit(deploy), None)
+
+    def test_deploy_with_limits_with_open_files_returns_value(self):
+        """ Test deploy with limits and open_files returns the configured value """
+        limits = ResourcesDefinition(open_files=65535)
+        resources = Resources(reservations=None, limits=limits)
+        deploy = Deploy(resources=resources)
+        self.assertEqual(open_files_limit(deploy), 65535)
+
+    def test_deploy_with_limits_without_open_files_and_custom_default(self):
+        """ Test deploy with no open_files but a custom default returns that default """
+        limits = ResourcesDefinition(open_files=None)
+        resources = Resources(reservations=None, limits=limits)
+        deploy = Deploy(resources=resources)
+        self.assertEqual(open_files_limit(deploy, default=4096), 4096)


### PR DESCRIPTION
# Add support for file descriptor limits in deployment schema

## Summary

This PR extends the OpenFactory deployment schema with support for configuring file descriptor limits through the `open_files` resource limit.

Example:

```yaml
deploy:
  resources:
    limits:
      cpus: 1.0
      memory: "1Gi"
      open_files: 65535
```

This PR introduces schema-level support only. Deployment backend integration (Docker / Docker Swarm) will be implemented in a follow-up PR.

## Motivation

OpenFactory applications that manage large numbers of devices or network connections may require more file descriptors than the default limit provided by the container runtime.

Recent scalability testing of OpenFactory gateways showed that file descriptor consumption scales with the number of connected devices. While file descriptor leaks have been resolved, applications may still require higher file descriptor limits to support large deployments.

OpenFactory already allows users to declare CPU and memory requirements through the deployment schema. This change extends the schema so applications can also declare file descriptor requirements.

## Changes

### Schema

Added an optional `open_files` field to `ResourcesDefinition`:

```python
open_files: Optional[int]
```

The field represents the maximum number of Linux file descriptors available to the application.

### Helper Function

Added:

```python
open_files_limit()
```

following the existing pattern used by:

```python
cpus_limit()
cpus_reservation()
```

### Documentation

Updated:

* deployment schema documentation
* application definition documentation
* YAML deployment examples
* field descriptions

to include `open_files`.

Documentation now clarifies that Linux file descriptors include files, network sockets, pipes, and other operating-system resources.

It also clarifies that when `open_files` is omitted, OpenFactory does not define a file descriptor limit and the default limit provided by the container runtime is used.

### Tests

Added:

* schema validation tests for `open_files`
* helper function tests for `open_files_limit`

## Example

```yaml
deploy:
  replicas: 2

  resources:
    reservations:
      cpus: 0.5
      memory: "512Mi"

    limits:
      cpus: 1.0
      memory: "1Gi"
      open_files: 65535

  placement:
    constraints:
      - node.labels.zone == building-a
```

## Future Work

Deployment backend support will be implemented in a separate PR.

This includes:

* Docker backend integration
* Docker Swarm backend integration
* Translation of `open_files` into runtime-specific file descriptor limits
* Backend integration tests
