### PR TITLE
Add open_files Support to Docker Deployment Backends

### DIFF
--- a/openfactory/openfactory_deploy_strategy.py
+++ b/openfactory/openfactory_deploy_strategy.py
@@ -22,6 +22,7 @@ Features:
   filesystems such as NFS.
 - Supports environment variables, container commands, labels, ports, networks,
   constraints, resource limits, and Docker mounts.
+- Supports configurable open file descriptor limits (ulimits) for containers and services.
 - Converts backend mount specifications (Local, NFS, Volume) into Docker-compatible mounts.
 - Handles Swarm-specific options (mode, constraints) transparently.
 - Provides user-friendly defaults for local container deployment.
@@ -38,6 +39,7 @@ Usage Example:
         name="scheduler",
         user="1234:5678",
         env=["ENV=production"],
+        open_files=65535,
         mounts=[{
             "Type": "bind",
             "Source": "/opt/openfactory/data",
@@ -54,6 +56,7 @@ Usage Example:
         name="reporter",
         user="1234:5678",
         env=["LOG_LEVEL=info"],
+        open_files=65535,
         mounts=[{
             "Type": "nfs",
             "Source": "192.168.0.100:/exports/reports",
@@ -70,7 +73,7 @@ to standardize service deployment across local development and production enviro
 """
 
 import docker
-from docker.types import Mount, DriverConfig
+from docker.types import Mount, DriverConfig, Ulimit, ContainerSpec, TaskTemplate, EndpointSpec, Placement
 from abc import ABC, abstractmethod
 from typing import List, Dict, Optional, Any, Literal
 from openfactory.docker.docker_access_layer import dal
@@ -95,6 +98,7 @@ class OpenFactoryServiceDeploymentStrategy(ABC):
                networks: Optional[List[str]] = None,
                constraints: Optional[List[str]] = None,
                resources: Optional[Dict[str, Any]] = None,
+               open_files: Optional[int] = None,
                mode: Optional[Dict[str, Any]] = None,
                mounts: Optional[List[dict]] = None) -> None:
         """
@@ -109,12 +113,15 @@ class OpenFactoryServiceDeploymentStrategy(ABC):
             user (Optional[str]): Runtime user in Docker format ``UID:GID``.
             name (str): Name of the service or container.
             env (List[str]): Environment variables in `KEY=VALUE` format.
-            labels (Optional[Dict[str, str]]): Metadata labels (Swarm only).
+            labels (Optional[Dict[str, str]]): Metadata labels attached to the deployed container or service.
             command (Optional[str]): Command to override the default entrypoint.
             ports (Optional[Dict[int, int]]): Port mappings from host to container (host:container).
             networks (Optional[List[str]]): Networks to connect the service or container to.
             constraints (Optional[List[str]]): Constraints for placement (Swarm only).
             resources (Optional[Dict[str, Any]]): Resource limits and reservations.
+            open_files (Optional[int]): Maximum number of open file descriptors
+                (RLIMIT_NOFILE) available to the process inside the container.
+                If not specified, the container runtime default is used.
             mode (Optional[Dict[str, Any]]): Service mode (Swarm only).
             mounts (Optional[List[dict]]): List of Docker mount specifications.
         """
@@ -132,7 +139,13 @@ class OpenFactoryServiceDeploymentStrategy(ABC):
 
 
 class SwarmDeploymentStrategy(OpenFactoryServiceDeploymentStrategy):
-    """ Deployment strategy for Docker Swarm mode. """
+    """
+    Deployment strategy for Docker Swarm mode.
+
+    Uses the Docker Engine API directly to create services, allowing support
+    for advanced container settings such as file descriptor limits (ulimits)
+    that are not exposed by the high-level Docker SDK service API.
+    """
 
     def deploy(self, *,
                image: str,
@@ -146,6 +159,7 @@ class SwarmDeploymentStrategy(OpenFactoryServiceDeploymentStrategy):
                networks: Optional[List[str]] = None,
                constraints: Optional[List[str]] = None,
                resources: Optional[Dict[str, Any]] = None,
+               open_files: Optional[int] = None,
                mode: Optional[Dict[str, Any]] = None,
                mounts: Optional[List[Mount]] = None) -> None:
         """
@@ -155,20 +169,41 @@ class SwarmDeploymentStrategy(OpenFactoryServiceDeploymentStrategy):
 
         Note:
             - ``image_pull_policy`` is currently ignored for Swarm deployments.
+            - When ``open_files`` is specified, the service is deployed with a ``nofile`` ulimit using identical soft and hard limits.
+            - If ``open_files`` is not specified, the Docker Engine default file descriptor limit is used.
         """
-        dal.docker_client.services.create(
+
+        container = ContainerSpec(
             image=image,
-            user=user,
-            name=name,
-            env=env,
-            labels=labels,
             command=command,
-            endpoint_spec=docker.types.EndpointSpec(ports=ports) if ports else None,
-            networks=networks,
-            constraints=constraints,
+            env=env,
+            user=user,
+            mounts=mounts,
+            labels=labels
+        )
+
+        if open_files is not None:
+            container["Ulimits"] = [
+                {
+                    "Name": "nofile",
+                    "Soft": open_files,
+                    "Hard": open_files
+                }
+            ]
+
+        task = TaskTemplate(
+            container,
             resources=resources,
+            placement=Placement(constraints=constraints) if constraints else None
+        )
+
+        dal.docker_client.api.create_service(
+            task,
+            name=name,
+            labels=labels,
             mode=mode,
-            mounts=mounts
+            networks=networks,
+            endpoint_spec=EndpointSpec(ports=ports) if ports else None
         )
 
     def remove(self, service_name):
@@ -231,6 +266,7 @@ class LocalDockerDeploymentStrategy(OpenFactoryServiceDeploymentStrategy):
                networks: Optional[List[str]] = None,
                constraints: Optional[List[str]] = None,
                resources: Optional[Dict[str, Any]] = None,
+               open_files: Optional[int] = None,
                mode: Optional[Dict[str, Any]] = None,
                mounts: Optional[List[dict]] = None) -> None:
         """
@@ -241,6 +277,8 @@ class LocalDockerDeploymentStrategy(OpenFactoryServiceDeploymentStrategy):
         Note:
             - ``constraints`` and ``mode`` are ignored for local containers.
             - ``image_pull_policy="always"`` forces a Docker image pull before deployment.
+            - When ``open_files`` is specified, a ``nofile`` ulimit is configured with identical soft and hard limits.
+            - If ``open_files`` is not specified, the Docker Engine default file descriptor limit is used.
         """
         client = docker.from_env()
 
@@ -261,6 +299,16 @@ class LocalDockerDeploymentStrategy(OpenFactoryServiceDeploymentStrategy):
         if image_pull_policy == "always":
             client.images.pull(image)
 
+        ulimits = None
+        if open_files is not None:
+            ulimits = [
+                Ulimit(
+                    name="nofile",
+                    soft=open_files,
+                    hard=open_files
+                )
+            ]
+
         container = client.containers.run(
             image=image,
             user=user,
@@ -272,7 +320,8 @@ class LocalDockerDeploymentStrategy(OpenFactoryServiceDeploymentStrategy):
             network=networks[0] if networks else None,
             labels=labels,
             nano_cpus=resources.get("Limits", {}).get("NanoCPUs") if resources else None,
-            mounts=docker_mounts
+            mounts=docker_mounts,
+            ulimits=ulimits
         )
 
         # Attach to additional networks

--- a/openfactory/openfactory_manager.py
+++ b/openfactory/openfactory_manager.py
@@ -48,7 +48,7 @@ from openfactory import OpenFactory
 from openfactory.schemas.devices import get_devices_from_config_file
 from openfactory.schemas.apps import OpenFactoryAppSchema, get_apps_from_config_file, normalize_name
 from openfactory.schemas.uns import UNSSchema
-from openfactory.schemas.common import constraints, resources
+from openfactory.schemas.common import constraints, resources, open_files_limit
 from openfactory.assets import Asset
 from openfactory.exceptions import OFAException
 from openfactory.models.user_notifications import user_notify
@@ -284,6 +284,7 @@ class OpenFactoryManager(OpenFactory):
                 mode={"Replicated": {"Replicas": 1}},
                 env=env,
                 resources=resources(application.deploy),
+                open_files=open_files_limit(application.deploy),
                 constraints=constraints(application.deploy),
                 networks=application.networks,
                 mounts=mounts,

--- a/tests/openfactory/test_openfactory_deploy_strategy.py
+++ b/tests/openfactory/test_openfactory_deploy_strategy.py
@@ -12,9 +12,9 @@ class TestSwarmDeploymentStrategy(unittest.TestCase):
     @patch("openfactory.openfactory_deploy_strategy.dal.docker_client")
     def test_swarm_deploy(self, mock_docker_client):
         """ Test Docker Swarm deploy method """
-        mock_create = MagicMock()
-        mock_docker_client.services.create = mock_create
+
         strategy = SwarmDeploymentStrategy()
+
         strategy.deploy(
             image="test-image",
             name="test-service",
@@ -28,18 +28,33 @@ class TestSwarmDeploymentStrategy(unittest.TestCase):
             mode={"Replicated": {"Replicas": 2}}
         )
 
-        mock_create.assert_called_once()
-        args, kwargs = mock_create.call_args
-        self.assertEqual(kwargs["image"], "test-image")
+        mock_docker_client.api.create_service.assert_called_once()
+
+        args, kwargs = mock_docker_client.api.create_service.call_args
+        task = args[0]
+
+        self.assertEqual(task["ContainerSpec"]["Image"], "test-image")
+        self.assertEqual(task["ContainerSpec"]["Env"], ["ENV=prod"])
+        self.assertEqual(task["ContainerSpec"]["Labels"], {"role": "web"})
+        self.assertEqual(task["ContainerSpec"]["Command"], ["run"])
+        self.assertEqual(task["Resources"]["Limits"]["NanoCPUs"], 500000000)
+        self.assertEqual(task["Placement"]["Constraints"], ["node.role==manager"])
         self.assertEqual(kwargs["name"], "test-service")
-        self.assertEqual(kwargs["env"], ["ENV=prod"])
-        self.assertEqual(kwargs["labels"], {"role": "web"})
-        self.assertEqual(kwargs["command"], "run")
-        self.assertIsNotNone(kwargs["endpoint_spec"])
         self.assertEqual(kwargs["networks"], ["net1"])
-        self.assertEqual(kwargs["constraints"], ["node.role==manager"])
-        self.assertEqual(kwargs["resources"]["Limits"]["NanoCPUs"], 500000000)
         self.assertEqual(kwargs["mode"], {"Replicated": {"Replicas": 2}})
+        self.assertEqual(kwargs["labels"], {"role": "web"})
+        self.assertEqual(
+            kwargs["endpoint_spec"],
+            {
+                "Ports": [
+                    {
+                        "Protocol": "tcp",
+                        "PublishedPort": 8080,
+                        "TargetPort": 80
+                    }
+                ]
+            }
+        )
 
     @patch("openfactory.openfactory_deploy_strategy.dal.docker_client")
     def test_swarm_deploy_accepts_image_pull_policy(self, mock_docker_client):
@@ -54,14 +69,11 @@ class TestSwarmDeploymentStrategy(unittest.TestCase):
             env=["ENV=prod"]
         )
 
-        mock_docker_client.services.create.assert_called_once()
+        mock_docker_client.api.create_service.assert_called_once()
 
     @patch("openfactory.openfactory_deploy_strategy.dal.docker_client")
     def test_swarm_deploy_with_runtime_user(self, mock_docker_client):
         """ Test Docker Swarm deploy with runtime user """
-
-        mock_create = MagicMock()
-        mock_docker_client.services.create = mock_create
 
         strategy = SwarmDeploymentStrategy()
 
@@ -72,22 +84,19 @@ class TestSwarmDeploymentStrategy(unittest.TestCase):
             user="1234:5678"
         )
 
-        mock_create.assert_called_once()
+        mock_docker_client.api.create_service.assert_called_once()
 
-        _, kwargs = mock_create.call_args
+        args, _ = mock_docker_client.api.create_service.call_args
+        task = args[0]
 
-        self.assertIn("user", kwargs)
-        self.assertEqual(kwargs["user"], "1234:5678")
+        self.assertEqual(task["ContainerSpec"]["User"], "1234:5678")
 
-    @patch("openfactory.openfactory_deploy_strategy.docker.types.Mount")
     @patch("openfactory.openfactory_deploy_strategy.dal.docker_client")
-    def test_swarm_deploy_with_mounts(self, mock_docker_client, mock_mount_class):
+    def test_swarm_deploy_with_mounts(self, mock_docker_client):
         """ Test Docker Swarm deploy with mounts """
-        mock_create = MagicMock()
-        mock_docker_client.services.create = mock_create
+
         strategy = SwarmDeploymentStrategy()
 
-        # Simulated mount spec (what get_mount_spec() now returns)
         mounts = [{
             "Target": "/mnt/data",
             "Source": "nfs-prover3018-desk",
@@ -111,10 +120,55 @@ class TestSwarmDeploymentStrategy(unittest.TestCase):
             mounts=mounts
         )
 
-        # Check that the mounts list was passed to services.create
-        _, kwargs = mock_create.call_args
-        self.assertIn("mounts", kwargs)
-        self.assertEqual(kwargs["mounts"], mounts)
+        mock_docker_client.api.create_service.assert_called_once()
+
+        args, _ = mock_docker_client.api.create_service.call_args
+        task = args[0]
+
+        self.assertEqual(task["ContainerSpec"]["Mounts"], mounts)
+
+    @patch("openfactory.openfactory_deploy_strategy.dal.docker_client")
+    def test_swarm_deploy_with_open_files(self, mock_docker_client):
+        """ Test Docker Swarm deploy with open_files limit """
+
+        strategy = SwarmDeploymentStrategy()
+
+        strategy.deploy(
+            image="test-image",
+            name="test-service",
+            env=["ENV=prod"],
+            open_files=5000
+        )
+
+        args, _ = mock_docker_client.api.create_service.call_args
+
+        task = args[0]
+
+        self.assertEqual(
+            task["ContainerSpec"]["Ulimits"],
+            [{
+                "Name": "nofile",
+                "Soft": 5000,
+                "Hard": 5000
+            }]
+        )
+
+    @patch("openfactory.openfactory_deploy_strategy.dal.docker_client")
+    def test_swarm_deploy_without_open_files(self, mock_docker_client):
+        """ Test Docker Swarm deploy without open_files limit """
+
+        strategy = SwarmDeploymentStrategy()
+
+        strategy.deploy(
+            image="test-image",
+            name="test-service",
+            env=["ENV=prod"]
+        )
+
+        args, _ = mock_docker_client.api.create_service.call_args
+        task = args[0]
+
+        self.assertNotIn("Ulimits", task["ContainerSpec"])
 
     @patch("openfactory.openfactory_deploy_strategy.dal.docker_client")
     def test_swarm_remove(self, mock_docker_client):
@@ -127,6 +181,46 @@ class TestSwarmDeploymentStrategy(unittest.TestCase):
 
         mock_docker_client.services.get.assert_called_once_with("test-service")
         mock_service.remove.assert_called_once_with()
+
+    @patch("openfactory.openfactory_deploy_strategy.dal.docker_client")
+    def test_swarm_deploy_without_resources(self, mock_docker_client):
+        """ Test Docker Swarm deploy without resources """
+
+        strategy = SwarmDeploymentStrategy()
+
+        strategy.deploy(
+            image="test-image",
+            name="test-service",
+            env=["ENV=prod"],
+            resources=None
+        )
+
+        mock_docker_client.api.create_service.assert_called_once()
+
+        args, _ = mock_docker_client.api.create_service.call_args
+        task = args[0]
+
+        self.assertNotIn("Resources", task)
+
+    @patch("openfactory.openfactory_deploy_strategy.dal.docker_client")
+    def test_swarm_deploy_without_constraints(self, mock_docker_client):
+        """ Test Docker Swarm deploy without constraints """
+
+        strategy = SwarmDeploymentStrategy()
+
+        strategy.deploy(
+            image="test-image",
+            name="test-service",
+            env=["ENV=prod"],
+            constraints=None
+        )
+
+        mock_docker_client.api.create_service.assert_called_once()
+
+        args, _ = mock_docker_client.api.create_service.call_args
+        task = args[0]
+
+        self.assertNotIn("Placement", task)
 
 
 class TestLocalDockerDeploymentStrategy(unittest.TestCase):
@@ -165,6 +259,8 @@ class TestLocalDockerDeploymentStrategy(unittest.TestCase):
         self.assertEqual(kwargs["network"], "bridge")
         self.assertEqual(kwargs["labels"], {"type": "api"})
         self.assertEqual(kwargs["nano_cpus"], 1000000000)
+        self.assertIn("ulimits", kwargs)
+        self.assertIsNone(kwargs["ulimits"])
 
     @patch("openfactory.openfactory_deploy_strategy.docker.from_env")
     def test_local_deploy_image_pull_policy_always(self, mock_from_env):
@@ -427,3 +523,51 @@ class TestLocalDockerDeploymentStrategy(unittest.TestCase):
         self.assertFalse(mock_client.networks.get.called)
         # container.connect should also NOT be called
         self.assertFalse(mock_client.networks.get.return_value.connect.called)
+
+    @patch("openfactory.openfactory_deploy_strategy.Ulimit")
+    @patch("openfactory.openfactory_deploy_strategy.docker.from_env")
+    def test_local_deploy_with_open_files(self, mock_from_env, mock_ulimit):
+        """ Test local Docker deploy with open_files limit """
+
+        mock_client = MagicMock()
+        mock_run = MagicMock()
+
+        mock_client.containers.run = mock_run
+        mock_from_env.return_value = mock_client
+
+        strategy = LocalDockerDeploymentStrategy()
+
+        strategy.deploy(
+            image="test-image",
+            name="test-container",
+            env=["ENV=dev"],
+            open_files=5000
+        )
+
+        mock_ulimit.assert_called_once_with(name="nofile", soft=5000, hard=5000)
+
+        _, kwargs = mock_run.call_args
+        self.assertIn("ulimits", kwargs)
+        self.assertEqual(kwargs["ulimits"], [mock_ulimit.return_value])
+
+    @patch("openfactory.openfactory_deploy_strategy.Ulimit")
+    @patch("openfactory.openfactory_deploy_strategy.docker.from_env")
+    def test_local_deploy_without_open_files(self, mock_from_env, mock_ulimit):
+        """ Test local Docker deploy without open_files limit """
+
+        mock_client = MagicMock()
+        mock_client.containers.run = MagicMock()
+        mock_from_env.return_value = mock_client
+
+        strategy = LocalDockerDeploymentStrategy()
+
+        strategy.deploy(
+            image="test-image",
+            name="test-container",
+            env=["ENV=dev"]
+        )
+
+        mock_ulimit.assert_not_called()
+        _, kwargs = mock_client.containers.run.call_args
+        self.assertIn("ulimits", kwargs)
+        self.assertIsNone(kwargs["ulimits"])

--- a/tests/openfactory/test_openfactorymanager.py
+++ b/tests/openfactory/test_openfactorymanager.py
@@ -483,6 +483,8 @@ class TestOpenFactoryManager(unittest.TestCase):
         self.assertIsNone(kwargs["constraints"])
         self.assertIsNone(kwargs["networks"])
         self.assertEqual(kwargs["mounts"], [])
+        self.assertIn("open_files", kwargs)
+        self.assertIsNone(kwargs["open_files"])
 
         # labels should be present (empty because no routing)
         self.assertIn("labels", kwargs)
@@ -623,6 +625,49 @@ class TestOpenFactoryManager(unittest.TestCase):
         deploy_call = self.manager.deployment_strategy.deploy.call_args
         self.assertIsNone(deploy_call.kwargs["resources"])
         self.assertIsNone(deploy_call.kwargs["constraints"])
+
+    @patch("openfactory.openfactory_manager.register_asset")
+    @patch("openfactory.openfactory_manager.user_notify")
+    def test_deploy_openfactory_application_passes_open_files_limit(self, mock_user_notify, mock_register_asset):
+        """ open_files limit should be passed to deployment strategy """
+
+        app = OpenFactoryAppSchema(
+            uuid="APP_OPEN_FILES",
+            image="app_image",
+            deploy=Deploy(
+                resources=Resources(
+                    limits=ResourcesDefinition(
+                        open_files=5000
+                    )
+                )
+            )
+        )
+
+        self.manager.deploy_openfactory_application(app)
+
+        deploy_call = self.manager.deployment_strategy.deploy.call_args
+        kwargs = deploy_call.kwargs
+
+        self.assertIn("open_files", kwargs)
+        self.assertEqual(kwargs["open_files"], 5000)
+
+    @patch("openfactory.openfactory_manager.register_asset")
+    @patch("openfactory.openfactory_manager.user_notify")
+    def test_deploy_openfactory_application_without_open_files_limit(self, mock_user_notify, mock_register_asset):
+        """ open_files should be None when not configured """
+
+        app = OpenFactoryAppSchema(
+            uuid="APP_NO_OPEN_FILES",
+            image="app_image"
+        )
+
+        self.manager.deploy_openfactory_application(app)
+
+        deploy_call = self.manager.deployment_strategy.deploy.call_args
+        kwargs = deploy_call.kwargs
+
+        self.assertIn("open_files", kwargs)
+        self.assertIsNone(kwargs["open_files"])
 
     @patch("openfactory.openfactory_manager.user_notify")
     @patch("openfactory.openfactory_manager.register_asset")


### PR DESCRIPTION
# Add `open_files` Support to Docker Deployment Backends

## Summary

This PR extends the OpenFactory deployment backends to support the newly introduced `deploy.resources.limits.open_files` configuration option (https://github.com/openfactoryio/openfactory-core/pull/329).

When specified, OpenFactory now configures the container's `RLIMIT_NOFILE` (`nofile` ulimit), allowing applications to safely handle large numbers of concurrent file descriptors such as network connections, sockets, and streams.

## Changes

### Docker Swarm

Updated `SwarmDeploymentStrategy` to support file descriptor limits.

Key changes:

* Added `open_files` parameter to the deployment interface.
* Switched Swarm deployment to the Docker Engine low-level API.
* Generates and injects a `nofile` ulimit into the service `ContainerSpec`.
* Uses identical soft and hard limits.

Example generated configuration:

```json
{
  "Name": "nofile",
  "Soft": 65535,
  "Hard": 65535
}
```

### Local Docker

Updated `LocalDockerDeploymentStrategy` to support file descriptor limits.

Key changes:

* Added `open_files` parameter to the deployment interface.
* Creates Docker SDK `Ulimit` objects when configured.
* Passes generated ulimits to `containers.run()`.

Example:

```python
Ulimit(
    name="nofile",
    soft=65535,
    hard=65535
)
```

### Documentation

Updated deployment strategy documentation and docstrings to:

* Document the new `open_files` parameter.
* Explain the purpose of file descriptor limits.
* Clarify that Docker defaults are used when the setting is omitted.

### Tests

Extended deployment strategy unit tests to cover:

#### Docker Swarm

* Deployment with `open_files`
* Deployment without `open_files`

#### Local Docker

* Deployment with `open_files`
* Deployment without `open_files`

Additional Swarm deployment assertions were added to validate generated service labels and endpoint specifications.

## Motivation

Many industrial applications maintain large numbers of concurrent network connections.

Examples include:

* OPC UA gateways managing hundreds of devices
* MQTT brokers and protocol gateways
* Kafka-based integration services
* High-density data acquisition systems

The default Docker file descriptor limits may become a bottleneck in such deployments.

The new configuration option allows applications to explicitly request higher limits when required while preserving existing behavior for all current deployments.

## Backward Compatibility

This change is fully backward compatible.

If `deploy.resources.limits.open_files` is not specified, OpenFactory does not configure any ulimit and the Docker Engine defaults continue to be used unchanged.
