### PR TITLE
Improve the resilience and observability of the Asset Forwarder Kafka consumer.

### DIFF
--- a/openfactory/fanoutlayer/asset_forwarder/src/asset_forwarder_metrics.py
+++ b/openfactory/fanoutlayer/asset_forwarder/src/asset_forwarder_metrics.py
@@ -106,6 +106,13 @@ QUEUE_SIZE_HISTOGRAM = Histogram(
     labelnames=("forwarder",),
 )
 
+# Kafka consume calls
+KAFKA_CONSUME_CALLS = Counter(
+    "asset_forwarder_kafka_consume_calls_total",
+    "Total number of completed Kafka consume() calls",
+    ["forwarder"]
+)
+
 
 def metrics_endpoint() -> Response:
     """

--- a/openfactory/fanoutlayer/asset_forwarder/src/asset_forwarder_service.py
+++ b/openfactory/fanoutlayer/asset_forwarder/src/asset_forwarder_service.py
@@ -52,6 +52,7 @@ The service exposes Prometheus metrics including:
 - Queue backlog.
 - Queue waiting time.
 - Message processing latency.
+- Kafka consume call rate.
 
 The Prometheus endpoint is exposed through the OpenFactory
 application framework.
@@ -96,6 +97,9 @@ class AssetForwarderService(OpenFactoryFastAPIApp):
         """
         super().__init__(*args, **kwargs)
 
+        # Consumer assignment flag
+        self.consumer_has_been_assigned = False
+
         # forwarder queue
         self.queue = asyncio.Queue(maxsize=int(os.getenv("ASSET_FORWARDER_QUEUE_SIZE", "10000")))
 
@@ -113,6 +117,31 @@ class AssetForwarderService(OpenFactoryFastAPIApp):
 
         # Expose Prometheus metrics
         self.api.get(PROMETHEUS_METRICS_PATH)(forwarder_metrics.metrics_endpoint)
+
+    def _error_cb(self, err: KafkaError) -> None:
+        """
+        Handle asynchronous Kafka client errors.
+
+        Called by the underlying librdkafka client when an asynchronous
+        client-level error occurs. These errors are independent of message
+        consumption and may indicate connection failures, broker issues,
+        group coordination problems, or other internal client events.
+
+        This callback is intended for diagnostics and monitoring. It does
+        not receive message-specific errors, which are reported through
+        :meth:`Message.error()`.
+
+        Args:
+            err: Kafka client error reported by librdkafka.
+        """
+        self.logger.error(
+            "Kafka client error: code=%s name=%s fatal=%s retriable=%s message=%s",
+            err.code(),
+            err.name(),
+            err.fatal(),
+            err.retriable(),
+            err,
+        )
 
     def setup_consumer(self) -> None:
         """
@@ -145,6 +174,7 @@ class AssetForwarderService(OpenFactoryFastAPIApp):
             "enable.auto.offset.store": False,
             "auto.commit.interval.ms": float(os.getenv("KAFKA_CONSUMER_COMMIT_INTERVAL_MS", "100")),
             "auto.offset.reset": os.getenv("KAFKA_AUTO_OFFSET_RESET", "latest"),
+            "error_cb": self._error_cb,
         }
 
         self.consumer = Consumer(self.kafka_config)
@@ -173,20 +203,33 @@ class AssetForwarderService(OpenFactoryFastAPIApp):
         """
         Handle Kafka partition assignment and register metrics.
 
-        Called by the Kafka consumer during a rebalance when partitions
-        are assigned to this consumer instance.
+        Called by the Kafka consumer when partitions are assigned to this
+        consumer. The callback updates the consumer state, explicitly assigns
+        the partitions to the consumer, and registers the Prometheus metrics
+        endpoint.
         """
-        self.logger.info("Assigned: %s", partitions)
+        self.logger.info("Assigned partitions: %s", partitions)
+        self.consumer_has_been_assigned = True
 
         if not partitions:
             self.logger.critical("Kafka consumer was assigned zero partitions. "
-                                 "Are there too many forwarders running comapred to topic partions ?")
+                                 "Are there too many forwarders running compared to topic partitions ?")
             os._exit(1)
 
-        consumer.assign(partitions)
+        try:
+            consumer.assign(partitions)
+        except Exception as e:
+            self.logger.error("consumer.assign() failed. Exception=%s: %s", type(e).__name__, e, exc_info=True)
+            raise
 
-        # register Prometheus metrics
-        self.register_prometheus_metrics(metrics_port=4000, metrics_path=PROMETHEUS_METRICS_PATH)
+        try:
+            self.logger.info("Registering Prometheus metrics")
+            self.register_prometheus_metrics(metrics_port=4000, metrics_path=PROMETHEUS_METRICS_PATH)
+        except Exception as e:
+            self.logger.error("Failed to register Prometheus metrics. Exception=%s: %s", type(e).__name__, e, exc_info=True)
+            raise
+
+        self.logger.info("Leaving assign")
 
     def _on_revoke(self, consumer: Consumer, partitions: list[TopicPartition]) -> None:
         """
@@ -196,11 +239,28 @@ class AssetForwarderService(OpenFactoryFastAPIApp):
         are revoked from this consumer instance. Pending offsets are
         committed before ownership is transferred to another consumer.
         """
-        self.logger.info("Revoked: %s", partitions)
+        self.logger.info("Revoked partitions: %s", partitions)
+
         try:
             consumer.commit(asynchronous=False)
-        except Exception:
-            pass
+        except Exception as e:
+            self.logger.error("Commit failed. Exception=%s: %s", type(e).__name__, e, exc_info=True)
+
+    def _on_lost(self, consumer: Consumer, partitions: list[TopicPartition]) -> None:
+        """
+        Handle Kafka partition loss.
+
+        Called when the consumer loses ownership of one or more partitions.
+
+        Unlike ``_on_revoke()``, the consumer no longer owns these partitions,
+        so offsets must not be committed. The callback is used for diagnostics
+        only; recovery is handled by librdkafka.
+
+        Args:
+            consumer: Kafka consumer instance.
+            partitions: List of lost partitions.
+        """
+        self.logger.critical("Partitions lost: %s", partitions)
 
     def decode_message_value(self, raw_value: bytes | bytearray | str) -> dict[str, Any]:
         """
@@ -341,6 +401,7 @@ class AssetForwarderService(OpenFactoryFastAPIApp):
                 try:
                     processing_time = asyncio.get_running_loop().time() - processing_start
                     forwarder_metrics.MESSAGE_PROCESSING_LATENCY.labels(forwarder=self.asset_uuid).observe(processing_time)
+                    forwarder_metrics.QUEUE_SIZE.labels(forwarder=self.asset_uuid).set(self.queue.qsize())
                 except Exception:
                     self.logger.exception("Failed to update processing latency metric")
                 self.queue.task_done()
@@ -349,12 +410,13 @@ class AssetForwarderService(OpenFactoryFastAPIApp):
         """
         Main service loop.
 
-        Starts worker tasks, subscribes to Kafka, consumes messages,
-        and queues them for asynchronous processing.
+        Starts the worker and Kafka watchdog tasks, subscribes to Kafka,
+        consumes messages, and queues them for asynchronous processing.
         """
 
         # worker task
         self.worker_task = asyncio.create_task(self.worker())
+        self.watchdog_task = asyncio.create_task(self.kafka_watchdog())
 
         def worker_done(task: asyncio.Task) -> None:
             """
@@ -370,13 +432,35 @@ class AssetForwarderService(OpenFactoryFastAPIApp):
             if exc:
                 self.logger.exception("Worker task crashed", exc_info=exc)
 
+        def watchdog_done(task: asyncio.Task) -> None:
+            """
+            Log unexpected Kafka watchdog task failures.
+
+            If the consumer remains without a partition assignment beyond the
+            configured grace period, the process is terminated so that the
+            container runtime can restart it and force a fresh Kafka consumer
+            join.
+
+            Args:
+                task: Completed watchdog task.
+            """
+            try:
+                exc = task.exception()
+            except asyncio.CancelledError:
+                return
+            if exc:
+                self.logger.exception("Kafka watchdog task crashed", exc_info=exc)
+                os._exit(1)
+
         self.worker_task.add_done_callback(worker_done)
+        self.watchdog_task.add_done_callback(watchdog_done)
 
         # Kafka subscription
         self.consumer.subscribe(
             [self.kafka_topic],
             on_assign=self._on_assign,
             on_revoke=self._on_revoke,
+            on_lost=self._on_lost,
         )
 
         while True:
@@ -385,6 +469,7 @@ class AssetForwarderService(OpenFactoryFastAPIApp):
                 num_messages=self.KAFKA_CONSUMER_BATCH_SIZE,
                 timeout=self.KAFKA_CONSUMER_TIME_OUT_MS / 1000.0,
             )
+            forwarder_metrics.KAFKA_CONSUME_CALLS.labels(forwarder=self.asset_uuid).inc()
 
             for msg in msgs:
 
@@ -419,6 +504,62 @@ class AssetForwarderService(OpenFactoryFastAPIApp):
                     "queued_at": asyncio.get_running_loop().time(),
                 })
                 forwarder_metrics.QUEUE_SIZE.labels(forwarder=self.asset_uuid).set(self.queue.qsize())
+
+    async def kafka_watchdog(self) -> None:
+        """
+        Monitor the Kafka consumer health.
+
+        Periodically verifies that the consumer still owns at least one
+        partition. If the consumer remains without any partition assignment,
+        the process is terminated so that the container can be restarted.
+
+        A grace period is used because a temporary lack of assignment is
+        normal during consumer group rebalances.
+        """
+        self.logger.debug("Started Kafka Watchdog.")
+
+        check_interval = float(os.getenv("KAFKA_WATCHDOG_INTERVAL", "30"))
+        max_unassigned_time = float(os.getenv("KAFKA_WATCHDOG_TIMEOUT", "300"))
+
+        unassigned_since = None
+
+        while True:
+            await asyncio.sleep(check_interval)
+
+            if not self.consumer_has_been_assigned:
+                continue
+
+            try:
+                assignment = self.consumer.assignment()
+                self.logger.debug("Current assignment: %s", assignment)
+            except Exception as e:
+                self.logger.exception("Kafka watchdog failed. Exception=%s: %s", type(e).__name__, e)
+                os._exit(1)
+
+            if assignment:
+                if unassigned_since is not None:
+                    self.logger.info("Kafka consumer has received a partition assignment again.")
+                unassigned_since = None
+                self.consumer_has_been_assigned = True
+                continue
+
+            now = asyncio.get_running_loop().time()
+
+            if unassigned_since is None:
+                unassigned_since = now
+                self.logger.warning(
+                    "Kafka consumer has no partition assignment. "
+                    "Waiting for rebalance..."
+                )
+                continue
+
+            if now - unassigned_since >= max_unassigned_time:
+                self.logger.critical(
+                    "Kafka consumer has had no partition assignment for %.0f seconds. "
+                    "Terminating so the container can be restarted.",
+                    max_unassigned_time,
+                )
+                os._exit(1)
 
 
 if __name__ == "__main__":

--- a/openfactory/fanoutlayer/prometheus/fan_out_layer_rules.yml
+++ b/openfactory/fanoutlayer/prometheus/fan_out_layer_rules.yml
@@ -36,6 +36,13 @@ groups:
           component: "fan_out_layer"
           role: "forwarder"
 
+      # Kafka consume() calls per forwarder (calls/sec)
+      - record: forwarder:kafka_consume_calls_rate
+        expr: rate(asset_forwarder_kafka_consume_calls_total[1m])
+        labels:
+          component: "fan_out_layer"
+          role: "forwarder"
+
       # Message throughput per NATS Cluster (messages/sec)
       - record: forwarder:messages_published_rate
         expr: rate(asset_forwarder_nats_messages_published_total[1m])

--- a/tests/openfactory/fanoutlayer/asset_forwarder/test_asset_forwarder_service.py
+++ b/tests/openfactory/fanoutlayer/asset_forwarder/test_asset_forwarder_service.py
@@ -268,10 +268,7 @@ class TestAssetForwarderService(unittest.TestCase):
 
         self.service._on_assign(consumer, partitions)
 
-        self.service.logger.info.assert_called_once_with(
-            "Assigned: %s",
-            partitions
-        )
+        self.service.logger.info.assert_any_call("Assigned partitions: %s", partitions)
 
     def test_on_assign(self):
         """ Test partition assignment callback. """
@@ -299,12 +296,39 @@ class TestAssetForwarderService(unittest.TestCase):
 
         self.service.logger.critical.assert_called_once_with(
             "Kafka consumer was assigned zero partitions. "
-            "Are there too many forwarders running comapred to topic partions ?"
+            "Are there too many forwarders running compared to topic partitions ?"
         )
 
         mock_exit.assert_called_once_with(1)
         consumer.assign.assert_not_called()
         self.service.register_prometheus_metrics.assert_not_called()
+
+    def test_on_assign_assign_failure(self):
+        """ Test assign failure is logged and re-raised. """
+        consumer = MagicMock()
+        consumer.assign.side_effect = RuntimeError("boom")
+
+        self.service.register_prometheus_metrics = MagicMock()
+
+        with self.assertRaises(RuntimeError):
+            self.service._on_assign(consumer, [MagicMock()])
+
+        self.service.logger.error.assert_called_once()
+        self.service.register_prometheus_metrics.assert_not_called()
+
+    def test_on_assign_register_metrics_failure(self):
+        """ Test metrics registration failure is logged and re-raised. """
+        consumer = MagicMock()
+
+        self.service.register_prometheus_metrics = MagicMock(
+            side_effect=RuntimeError("boom")
+        )
+
+        with self.assertRaises(RuntimeError):
+            self.service._on_assign(consumer, [MagicMock()])
+
+        consumer.assign.assert_called_once()
+        self.service.logger.error.assert_called_once()
 
     def test_on_revoke(self):
         """ Test partition revocation callback. """
@@ -322,7 +346,7 @@ class TestAssetForwarderService(unittest.TestCase):
 
         self.service._on_revoke(consumer, partitions)
 
-        self.service.logger.info.assert_called_once_with("Revoked: %s", partitions)
+        self.service.logger.info.assert_called_once_with("Revoked partitions: %s", partitions)
 
     def test_on_revoke_commit_failure(self):
         """ Test that revoke continues if commit fails. """
@@ -330,3 +354,40 @@ class TestAssetForwarderService(unittest.TestCase):
         consumer.commit.side_effect = Exception()
 
         self.service._on_revoke(consumer, [])
+
+        self.service.logger.error.assert_called_once_with(
+            "Commit failed. Exception=%s: %s",
+            "Exception",
+            consumer.commit.side_effect,
+            exc_info=True,
+        )
+
+    def test_on_lost_logs(self):
+        """ Test partition loss logging. """
+        consumer = MagicMock()
+        partitions = [MagicMock()]
+
+        self.service._on_lost(consumer, partitions)
+
+        self.service.logger.critical.assert_called_once_with("Partitions lost: %s", partitions)
+
+    def test_error_cb_logs(self):
+        """ Test Kafka client error callback logging. """
+
+        err = MagicMock()
+        err.code.return_value = -195
+        err.name.return_value = "_TRANSPORT"
+        err.fatal.return_value = False
+        err.retriable.return_value = True
+        err.__str__.return_value = "connection refused"
+
+        self.service._error_cb(err)
+
+        self.service.logger.error.assert_called_once_with(
+            "Kafka client error: code=%s name=%s fatal=%s retriable=%s message=%s",
+            -195,
+            "_TRANSPORT",
+            False,
+            True,
+            err,
+        )

--- a/tests/openfactory/fanoutlayer/asset_forwarder/test_asset_forwarder_service_main_loop.py
+++ b/tests/openfactory/fanoutlayer/asset_forwarder/test_asset_forwarder_service_main_loop.py
@@ -35,6 +35,7 @@ class TestAssetForwarderMainLoop(unittest.IsolatedAsyncioTestCase):
             [self.service.kafka_topic],
             on_assign=self.service._on_assign,
             on_revoke=self.service._on_revoke,
+            on_lost=self.service._on_lost,
         )
 
     @patch("openfactory.fanoutlayer.asset_forwarder.src.asset_forwarder_service.forwarder_metrics")
@@ -129,6 +130,7 @@ class TestAssetForwarderMainLoop(unittest.IsolatedAsyncioTestCase):
 
         mock_metrics.KAFKA_ERRORS.labels.assert_called_once_with(forwarder=self.service.asset_uuid)
         mock_metrics.KAFKA_ERRORS.labels.return_value.inc.assert_called_once()
+        self.service.logger.error.assert_called_once()
 
     @patch("openfactory.fanoutlayer.asset_forwarder.src.asset_forwarder_service.os._exit")
     @patch("openfactory.fanoutlayer.asset_forwarder.src.asset_forwarder_service.forwarder_metrics")
@@ -155,13 +157,39 @@ class TestAssetForwarderMainLoop(unittest.IsolatedAsyncioTestCase):
 
         mock_metrics.KAFKA_ERRORS.labels.return_value.inc.assert_called_once()
         mock_exit.assert_called_once_with(1)
+        self.service.logger.critical.assert_called_once()
 
     @patch("openfactory.fanoutlayer.asset_forwarder.src.asset_forwarder_service.asyncio.create_task")
-    async def test_async_main_loop_starts_worker(self, mock_create_task):
-        """ Test worker task is started when main loop starts. """
+    async def test_async_main_loop_starts_worker_and_watchdog(self, mock_create_task):
+        """ Test worker and Kafka watchdog tasks are started. """
+
+        def create_task_side_effect(coro):
+            coro.close()  # Prevent "coroutine was never awaited" warnings.
+            return MagicMock()
+
+        mock_create_task.side_effect = create_task_side_effect
+
         self.service.consumer.consume.side_effect = asyncio.CancelledError()
 
         with self.assertRaises(asyncio.CancelledError):
             await self.service.async_main_loop()
 
-        mock_create_task.assert_called_once()
+        self.assertEqual(mock_create_task.call_count, 2)
+
+        self.assertEqual(mock_create_task.call_args_list[0].args[0].cr_code.co_name, "worker")
+        self.assertEqual(mock_create_task.call_args_list[1].args[0].cr_code.co_name, "kafka_watchdog")
+
+    @patch("openfactory.fanoutlayer.asset_forwarder.src.asset_forwarder_service.forwarder_metrics")
+    async def test_async_main_loop_increments_consume_calls_metric(self, mock_metrics):
+        """ Test Kafka consume call metric is incremented. """
+
+        self.service.worker = AsyncMock()
+        self.service.consumer.consume.side_effect = [
+            [],
+            asyncio.CancelledError(),
+        ]
+
+        with self.assertRaises(asyncio.CancelledError):
+            await self.service.async_main_loop()
+
+        self.assertEqual(mock_metrics.KAFKA_CONSUME_CALLS.labels.return_value.inc.call_count, 1)

--- a/tests/openfactory/fanoutlayer/asset_forwarder/test_asset_forwarder_service_watchdog.py
+++ b/tests/openfactory/fanoutlayer/asset_forwarder/test_asset_forwarder_service_watchdog.py
@@ -1,0 +1,174 @@
+import asyncio
+import unittest
+from unittest.mock import AsyncMock, MagicMock, patch
+from openfactory.fanoutlayer.asset_forwarder.src.asset_forwarder_service import AssetForwarderService
+
+
+class TestAssetForwarderWatchdog(unittest.IsolatedAsyncioTestCase):
+    """
+    Unit tests for the Kafka watchdog.
+    """
+
+    def setUp(self):
+        """ Create a service instance configured for watchdog testing. """
+        self.service = AssetForwarderService(
+            ksqlClient=MagicMock(),
+            bootstrap_servers="localhost:9092",
+            test_mode=True,
+        )
+
+        self.service.logger = MagicMock()
+        self.service.consumer = MagicMock()
+
+    @patch("openfactory.fanoutlayer.asset_forwarder.src.asset_forwarder_service.asyncio.sleep", new_callable=AsyncMock)
+    async def test_watchdog_waits_until_first_assignment(self, mock_sleep):
+        """ Test watchdog does nothing until the consumer has been assigned. """
+
+        self.service.consumer_has_been_assigned = False
+
+        mock_sleep.side_effect = asyncio.CancelledError()
+
+        with self.assertRaises(asyncio.CancelledError):
+            await self.service.kafka_watchdog()
+
+        self.service.consumer.assignment.assert_not_called()
+
+    @patch("openfactory.fanoutlayer.asset_forwarder.src.asset_forwarder_service.asyncio.sleep", new_callable=AsyncMock)
+    async def test_watchdog_continues_when_assignment_exists(self, mock_sleep):
+        """ Test watchdog continues normally when partitions are assigned. """
+
+        self.service.consumer_has_been_assigned = True
+        self.service.consumer.assignment.return_value = [MagicMock()]
+
+        # First iteration runs normally, second iteration stops the infinite loop.
+        mock_sleep.side_effect = [
+            None,
+            asyncio.CancelledError(),
+        ]
+
+        with self.assertRaises(asyncio.CancelledError):
+            await self.service.kafka_watchdog()
+
+        self.service.consumer.assignment.assert_called_once()
+        self.service.logger.warning.assert_not_called()
+        self.service.logger.info.assert_not_called()
+        self.service.logger.critical.assert_not_called()
+
+    @patch("openfactory.fanoutlayer.asset_forwarder.src.asset_forwarder_service.asyncio.sleep", new_callable=AsyncMock)
+    async def test_watchdog_logs_when_assignment_is_lost(self, mock_sleep):
+        """ Test watchdog logs when all partition assignments are lost. """
+
+        self.service.consumer_has_been_assigned = True
+        self.service.consumer.assignment.return_value = []
+
+        mock_sleep.side_effect = [
+            None,
+            asyncio.CancelledError(),
+        ]
+
+        with self.assertRaises(asyncio.CancelledError):
+            await self.service.kafka_watchdog()
+
+        self.service.consumer.assignment.assert_called_once()
+
+        self.service.logger.warning.assert_called_once_with(
+            "Kafka consumer has no partition assignment. "
+            "Waiting for rebalance..."
+        )
+
+    @patch("openfactory.fanoutlayer.asset_forwarder.src.asset_forwarder_service.asyncio.sleep", new_callable=AsyncMock)
+    async def test_watchdog_logs_when_assignment_returns(self, mock_sleep):
+        """ Test watchdog logs when a partition assignment is regained. """
+
+        self.service.consumer_has_been_assigned = True
+        self.service.consumer.assignment.side_effect = [
+            [],
+            [MagicMock()],
+        ]
+
+        mock_sleep.side_effect = [
+            None,
+            None,
+            asyncio.CancelledError(),
+        ]
+
+        with self.assertRaises(asyncio.CancelledError):
+            await self.service.kafka_watchdog()
+
+        self.assertEqual(self.service.consumer.assignment.call_count, 2)
+
+        self.service.logger.warning.assert_called_once_with(
+            "Kafka consumer has no partition assignment. "
+            "Waiting for rebalance..."
+        )
+
+        self.service.logger.info.assert_called_once_with(
+            "Kafka consumer has received a partition assignment again."
+        )
+
+    @patch("openfactory.fanoutlayer.asset_forwarder.src.asset_forwarder_service.os._exit", side_effect=SystemExit(1))
+    @patch("openfactory.fanoutlayer.asset_forwarder.src.asset_forwarder_service.asyncio.sleep", new_callable=AsyncMock)
+    async def test_watchdog_exits_when_assignment_check_fails(self, mock_sleep, mock_exit):
+        """ Test watchdog terminates if consumer.assignment() raises. """
+
+        self.service.consumer_has_been_assigned = True
+        self.service.consumer.assignment.side_effect = RuntimeError("boom")
+
+        mock_sleep.side_effect = [None]
+
+        with self.assertRaises(SystemExit):
+            await self.service.kafka_watchdog()
+
+        self.service.logger.exception.assert_called_once()
+        mock_exit.assert_called_once_with(1)
+
+    @patch("openfactory.fanoutlayer.asset_forwarder.src.asset_forwarder_service.os._exit", side_effect=SystemExit(1))
+    @patch("openfactory.fanoutlayer.asset_forwarder.src.asset_forwarder_service.asyncio.sleep", new_callable=AsyncMock)
+    @patch("openfactory.fanoutlayer.asset_forwarder.src.asset_forwarder_service.os.getenv")
+    async def test_watchdog_exits_after_assignment_timeout(self, mock_getenv, mock_sleep, mock_exit):
+        """ Test watchdog terminates if no partition assignment returns within the timeout. """
+
+        def getenv_side_effect(key, default=None):
+            if key == "KAFKA_WATCHDOG_INTERVAL":
+                return "1"
+            if key == "KAFKA_WATCHDOG_TIMEOUT":
+                return "2"
+            return default
+
+        mock_getenv.side_effect = getenv_side_effect
+
+        self.service.consumer_has_been_assigned = True
+        self.service.consumer.assignment.return_value = []
+
+        loop = asyncio.get_running_loop()
+
+        original_time = loop.time
+        times = iter([100.0, 103.0])
+
+        loop.time = MagicMock(side_effect=lambda: next(times))
+
+        mock_sleep.side_effect = [
+            None,
+            None,
+        ]
+
+        try:
+            with self.assertRaises(SystemExit):
+                await self.service.kafka_watchdog()
+        finally:
+            loop.time = original_time
+
+        self.assertEqual(self.service.consumer.assignment.call_count, 2)
+
+        self.service.logger.warning.assert_called_once_with(
+            "Kafka consumer has no partition assignment. "
+            "Waiting for rebalance..."
+        )
+
+        self.service.logger.critical.assert_called_once_with(
+            "Kafka consumer has had no partition assignment for %.0f seconds. "
+            "Terminating so the container can be restarted.",
+            2.0,
+        )
+
+        mock_exit.assert_called_once_with(1)


### PR DESCRIPTION
## Improve the resilience and observability of the Asset Forwarder Kafka consumer.

This PR introduces a Kafka watchdog that detects consumers that permanently lose their partition assignment, adds diagnostic logging for Kafka consumer lifecycle events, improves monitoring with a new Prometheus metric, and extends unit test coverage.

## Motivation

A production incident revealed a failure mode where the Asset Forwarder stopped consuming Kafka messages after a broker disruption while the process itself remained alive. Since the container stayed healthy, Docker Swarm never restarted it, leaving the fan-out layer permanently stalled.

Although normal Kafka broker restarts and consumer group rebalances recover correctly, the exact sequence that produced the production failure has not yet been reproduced. This PR improves diagnostics and introduces a defensive recovery mechanism so similar failures can no longer leave the forwarder silently inactive.

## Changes

### Kafka watchdog

* Add a watchdog task that continuously monitors the Kafka consumer assignment.
* Wait until the consumer receives its first partition assignment.
* Detect prolonged loss of all partition assignments.
* Gracefully tolerate normal Kafka rebalances.
* Terminate the process if no partition assignment is recovered within a configurable timeout, allowing Docker Swarm to restart the container.

### Kafka diagnostics

Improve logging for Kafka consumer lifecycle events, including:

* partition assignment
* partition revocation
* partition loss
* partition reassignment
* Kafka client errors

These logs provide significantly more information for diagnosing future production incidents.

### Monitoring

Add a new Prometheus metric:

* `asset_forwarder_kafka_consume_calls_total`

and a corresponding recording rule:

* `forwarder:kafka_consume_calls_rate`

This metric makes it possible to distinguish between a consumer that has stopped polling Kafka and one that is still polling but receiving no records.

### Testing

Expand unit test coverage for:

* Kafka assignment callbacks
* Kafka loss callback
* Kafka error callback
* watchdog behavior
* watchdog recovery
* watchdog timeout
* watchdog error handling
* new logging paths

## Configuration

Introduce two new environment variables:

* `KAFKA_WATCHDOG_INTERVAL`
* `KAFKA_WATCHDOG_TIMEOUT`

to configure the watchdog polling interval and the maximum tolerated time without a partition assignment.

## Expected impact

These changes improve the robustness of the Asset Forwarder against unexpected Kafka consumer failures while providing substantially better observability for diagnosing future issues.
