### PR TITLE
Allow disabling FastAPI HTTP request logging

### DIFF
--- a/openfactory/apps/ofa_fastapi_app.py
+++ b/openfactory/apps/ofa_fastapi_app.py
@@ -32,6 +32,7 @@ class OpenFactoryFastAPIApp(OpenFactoryApp):
         - The server listens on all network interfaces (``0.0.0.0``).
         - The listening port is defined by the ``PORT`` environment variable, or defaults to ``4000`` if unset.
         - The server log level is aligned with the OpenFactory application logger.
+        - HTTP access logging can be enabled or disabled using the ``log_http_requests`` constructor parameter.
 
     Attributes:
         api (fastapi.FastAPI): FastAPI application instance attached to the OpenFactory app.
@@ -147,6 +148,7 @@ class OpenFactoryFastAPIApp(OpenFactoryApp):
         bootstrap_servers: str | None = None,
         asset_router_url: str | None = None,
         loglevel: str = "INFO",
+        log_http_requests: bool = True,
         test_mode: bool = False,
     ) -> None:
         """
@@ -162,6 +164,7 @@ class OpenFactoryFastAPIApp(OpenFactoryApp):
             bootstrap_servers: Kafka bootstrap server address.
             asset_router_url: Asset Router URL.
             loglevel: Logging level (e.g., ``INFO``, ``DEBUG``).
+            log_http_requests: Enables logging of incoming HTTP requests handled by the embedded FastAPI server.
             test_mode: Enables test mode (disables live Kafka/ksql interaction).
 
         See also:
@@ -173,6 +176,7 @@ class OpenFactoryFastAPIApp(OpenFactoryApp):
                          loglevel=loglevel,
                          test_mode=test_mode)
 
+        self.log_http_requests = log_http_requests
         self._shutdown_event = asyncio.Event()
 
         # OPENFACTORY_ROOT_PATH is set by the OpenFactory deployment tool when the app is
@@ -242,6 +246,7 @@ class OpenFactoryFastAPIApp(OpenFactoryApp):
 
         Note:
             - The log level of the server is aligned with the OpenFactory application logger.
+            - Logging of incoming HTTP requests is controlled by the ``log_http_requests`` constructor parameter.
             - This method is intended for internal use and is called by :meth:`async_run`.
         """
         log_level = logging.getLevelName(self.logger.level).lower()
@@ -250,7 +255,8 @@ class OpenFactoryFastAPIApp(OpenFactoryApp):
             self.api,
             host="0.0.0.0",
             port=int(os.getenv("PORT", "4000")),
-            log_level=log_level
+            log_level=log_level,
+            access_log=self.log_http_requests
         )
         self._uvicorn_server = uvicorn.Server(config)
         await self._uvicorn_server.serve()

--- a/tests/openfactory/apps/test_openfactory_fastapi_app.py
+++ b/tests/openfactory/apps/test_openfactory_fastapi_app.py
@@ -245,3 +245,40 @@ class TestOpenFactoryFastAPIAppAsync(unittest.IsolatedAsyncioTestCase):
 
             _, kwargs = mock_config.call_args
             self.assertEqual(kwargs["port"], 5555)
+
+    @patch("openfactory.apps.ofa_fastapi_app.uvicorn.Server")
+    @patch("openfactory.apps.ofa_fastapi_app.uvicorn.Config")
+    async def test_run_fastapi_logs_http_requests_by_default(self, mock_config, mock_server):
+        """ Should enable HTTP request logging by default. """
+
+        app = OpenFactoryFastAPIApp(
+            ksqlClient=self.ksql_mock,
+            bootstrap_servers="mock",
+            asset_router_url="mock"
+        )
+
+        mock_server.return_value.serve = AsyncMock()
+
+        await app._run_fastapi()
+
+        _, kwargs = mock_config.call_args
+        self.assertTrue(kwargs["access_log"])
+
+    @patch("openfactory.apps.ofa_fastapi_app.uvicorn.Server")
+    @patch("openfactory.apps.ofa_fastapi_app.uvicorn.Config")
+    async def test_run_fastapi_disables_http_request_logs(self, mock_config, mock_server):
+        """ Should disable HTTP request logging when requested. """
+
+        app = OpenFactoryFastAPIApp(
+            ksqlClient=self.ksql_mock,
+            bootstrap_servers="mock",
+            asset_router_url="mock",
+            log_http_requests=False
+        )
+
+        mock_server.return_value.serve = AsyncMock()
+
+        await app._run_fastapi()
+
+        _, kwargs = mock_config.call_args
+        self.assertFalse(kwargs["access_log"])


### PR DESCRIPTION
## Allow disabling FastAPI HTTP request logging

This PR adds support for enabling or disabling HTTP request logging in `OpenFactoryFastAPIApp`.

Previously, Uvicorn access logs were always enabled, causing every incoming HTTP request (including frequent health checks) to be logged. This behavior is now configurable through a new constructor parameter while preserving the existing default behavior.

## Changes

* Added a new `log_http_requests` constructor parameter to `OpenFactoryFastAPIApp`.

  * Defaults to `True` for backward compatibility.
* Configured Uvicorn's `access_log` option using the new parameter.
* Updated the class and constructor documentation.
* Updated the `_run_fastapi()` documentation.
* Added unit tests covering both the default and disabled logging behavior.

## Example

```python
app = OpenFactoryFastAPIApp(
    ksqlClient=client,
    log_http_requests=False,
)
```

With `log_http_requests=False`, Uvicorn no longer emits HTTP access log entries while the application's own logging remains unchanged.

## Backward Compatibility

This change is fully backward compatible. Existing applications continue to log HTTP requests by default and require no modifications.
