### PR TITLE
add expose metrics convenience method to openfactoryfastapiapp

### DIFF
--- a/openfactory/apps/ofa_fastapi_app.py
+++ b/openfactory/apps/ofa_fastapi_app.py
@@ -2,6 +2,8 @@ import asyncio
 import os
 import uvicorn
 import logging
+from fastapi import Response
+from prometheus_client import CONTENT_TYPE_LATEST, REGISTRY, CollectorRegistry, generate_latest
 from openfactory.kafka import KSQLDBClient
 from openfactory.apps import OpenFactoryApp
 
@@ -127,6 +129,41 @@ class OpenFactoryFastAPIApp(OpenFactoryApp):
                 ofa_app.move_axis(x, y)
                 return {"message": "moving"}
 
+    Prometheus metrics can be exposed by calling :meth:`expose_metrics`.
+    By default, the global Prometheus registry is exposed, allowing both
+    OpenFactory metrics and application-defined metrics to be scraped
+    through the same endpoint.
+
+    .. admonition:: Exposing Prometheus metrics
+
+        .. code-block:: python
+
+            import asyncio
+            from prometheus_client import Counter
+            from openfactory.apps import OpenFactoryFastAPIApp
+
+            REQUESTS = Counter(
+                "requests_total",
+                "Number of processed requests"
+            )
+
+            class DemoFastAPIApp(OpenFactoryFastAPIApp):
+
+                def __init__(self, *args, **kwargs):
+                    super().__init__(*args, **kwargs)
+                    self.expose_metrics()
+
+                async def async_main_loop(self):
+                    while True:
+                        REQUESTS.inc()
+                        await asyncio.sleep(1)
+
+            app = DemoFastAPIApp(
+                ksqlClient=KSQLDBClient(os.getenv("KSQLDB_URL", "http://localhost:8088")),
+                bootstrap_servers=os.getenv("KAFKA_BROKER", "localhost:9092"),
+            )
+            app.run()
+
     Note:
       - The FastAPI application is accessible via :attr:`api` and behaves like a standard FastAPI instance.
       - Route definitions can be added either directly using :attr:`api` or via :class:`api.include_router() <fastapi.FastAPI>`.
@@ -140,6 +177,7 @@ class OpenFactoryFastAPIApp(OpenFactoryApp):
         - :class:`openfactory.apps.ofaapp.OpenFactoryApp`
         - :class:`fastapi.FastAPI`
         - `FastAPI documentation <https://fastapi.tiangolo.com/>`_
+        - `Prometheus Python Client documentation <https://prometheus.github.io/client_python/>`_
     """
 
     def __init__(
@@ -232,6 +270,51 @@ class OpenFactoryFastAPIApp(OpenFactoryApp):
             of overriding this method.
         """
         pass
+
+    def expose_metrics(self, path: str = "/metrics", registry: CollectorRegistry = REGISTRY) -> None:
+        """
+        Expose Prometheus metrics through the embedded FastAPI application.
+
+        Registers an HTTP endpoint that returns all metrics contained in the
+        specified Prometheus registry using the standard Prometheus exposition
+        format.
+
+        Calling this method also registers the metrics endpoint with the OpenFactory platform,
+        allowing other OpenFactory components to discover and scrape it automatically.
+
+        By default, the global Prometheus registry is exposed, allowing both OpenFactory metrics
+        and user-defined Prometheus metrics to be scraped through the same endpoint.
+
+        This method is idempotent. Calling it multiple times with the same
+        ``path`` has no effect.
+
+        Args:
+            path: URL path where metrics are exposed. Defaults to ``"/metrics"``.
+            registry: Prometheus registry to expose. Defaults to the global Prometheus registry.
+
+        Raises:
+            ValueError:
+                If another endpoint is already registered for ``path``.
+        """
+
+        # Already registered by this method -> do nothing
+        if getattr(self, "_metrics_path", None) == path:
+            return
+
+        # Prevent overriding an existing route
+        for route in self.api.routes:
+            if getattr(route, "path", None) == path:
+                raise ValueError(f"A route is already registered for '{path}'.")
+
+        @self.api.get(path)
+        async def metrics():
+            return Response(
+                generate_latest(registry),
+                media_type=CONTENT_TYPE_LATEST,
+            )
+
+        self._metrics_path = path
+        self.register_prometheus_metrics(metrics_port=int(os.getenv("PORT", "4000")), metrics_path=path)
 
     async def _run_fastapi(self) -> None:
         """

--- a/tests/openfactory/apps/test_openfactory_fastapi_app.py
+++ b/tests/openfactory/apps/test_openfactory_fastapi_app.py
@@ -50,6 +50,69 @@ class TestOpenFactoryFastAPIApp(unittest.TestCase):
 
         self.assertTrue(hasattr(app, "called"))
 
+    @patch.object(OpenFactoryFastAPIApp, "register_prometheus_metrics")
+    def test_expose_metrics_registers_route(self, mock_register):
+        """ Should register the Prometheus metrics endpoint. """
+
+        app = OpenFactoryFastAPIApp(
+            ksqlClient=self.ksql_mock,
+            bootstrap_servers="mock",
+            asset_router_url="mock",
+            test_mode=True
+        )
+
+        app.expose_metrics()
+
+        paths = [route.path for route in app.api.routes]
+        self.assertIn("/metrics", paths)
+        mock_register.assert_called_once_with(
+            metrics_port=4000,
+            metrics_path="/metrics"
+        )
+
+    @patch.object(OpenFactoryFastAPIApp, "register_prometheus_metrics")
+    def test_expose_metrics_is_idempotent(self, mock_register):
+        """ Calling expose_metrics twice should have no effect. """
+
+        app = OpenFactoryFastAPIApp(
+            ksqlClient=self.ksql_mock,
+            bootstrap_servers="mock",
+            asset_router_url="mock",
+            test_mode=True
+        )
+
+        app.expose_metrics()
+        app.expose_metrics()
+
+        paths = [
+            route.path
+            for route in app.api.routes
+            if route.path == "/metrics"
+        ]
+
+        self.assertEqual(len(paths), 1)
+        mock_register.assert_called_once()
+
+    @patch.object(OpenFactoryFastAPIApp, "register_prometheus_metrics")
+    def test_expose_metrics_rejects_existing_route(self, mock_register):
+        """ Should reject exposing metrics on an existing route. """
+
+        app = OpenFactoryFastAPIApp(
+            ksqlClient=self.ksql_mock,
+            bootstrap_servers="mock",
+            asset_router_url="mock",
+            test_mode=True
+        )
+
+        @app.api.get("/metrics")
+        async def metrics():
+            return {}
+
+        with self.assertRaisesRegex(ValueError, "A route is already registered"):
+            app.expose_metrics()
+
+        mock_register.assert_not_called()
+
 
 class TestOpenFactoryFastAPIAppAsync(unittest.IsolatedAsyncioTestCase):
     """

--- a/tests/openfactory/apps/test_openfactory_fastapi_app_http.py
+++ b/tests/openfactory/apps/test_openfactory_fastapi_app_http.py
@@ -15,6 +15,9 @@ class _HTTPTestApp(OpenFactoryFastAPIApp):
         # expose OFA app for router-style access if needed
         self.api.state.ofa_app = self
 
+        # expose prometheus metrics
+        self.expose_metrics()
+
         @self.api.get("/")
         async def root():
             return {"status": "ok"}
@@ -40,10 +43,15 @@ class TestOpenFactoryFastAPIAppHTTP(unittest.TestCase):
         self.deregister_patcher.start()
         self.addCleanup(self.deregister_patcher.stop)
 
+        self.register_metrics_patcher = patch.object(OpenFactoryFastAPIApp, "register_prometheus_metrics")
+        self.mock_register_metrics = self.register_metrics_patcher.start()
+        self.addCleanup(self.register_metrics_patcher.stop)
+
         self.app = _HTTPTestApp(
             ksqlClient=self.ksql_mock,
             bootstrap_servers="mock",
-            asset_router_url="mock"
+            asset_router_url="mock",
+            test_mode=True
         )
 
         self.client = TestClient(self.app.api)
@@ -61,3 +69,9 @@ class TestOpenFactoryFastAPIAppHTTP(unittest.TestCase):
     def test_invalid_route(self):
         response = self.client.get("/unknown")
         self.assertEqual(response.status_code, 404)
+
+    def test_metrics_endpoint(self):
+        """ Should expose Prometheus metrics. """
+        response = self.client.get("/metrics")
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("text/plain", response.headers["content-type"])


### PR DESCRIPTION
# Add `expose_metrics()` convenience method to `OpenFactoryFastAPIApp`

## Summary

This PR adds a new `expose_metrics()` convenience method to `OpenFactoryFastAPIApp` to simplify exposing Prometheus metrics from OpenFactory applications.

Previously, applications had to manually register a `/metrics` endpoint using the Prometheus client. With this change, applications can expose Prometheus metrics with a single method call:

```python
app.expose_metrics()
```

The endpoint exposes the global Prometheus registry by default, allowing both built-in OpenFactory metrics and application-defined Prometheus metrics to be scraped through the same endpoint.

## Changes

* Added `OpenFactoryFastAPIApp.expose_metrics()`.
* Exposes Prometheus metrics using the standard Prometheus exposition format.
* Supports custom endpoint paths and Prometheus registries.
* Registers the metrics endpoint with the OpenFactory platform via `register_prometheus_metrics()`.
* Prevents route conflicts by raising a `ValueError` if the requested path is already registered.
* Implements idempotent behavior when called multiple times with the same path.

## Documentation

* Added API documentation for `expose_metrics()`.
* Added a dedicated documentation example demonstrating how to expose Prometheus metrics and define custom application metrics.
* Added a reference to the Prometheus Python Client documentation.

## Tests

Added unit tests covering:

* registration of the metrics endpoint;
* idempotent behavior;
* detection of conflicting routes.

Added an HTTP integration test verifying that the `/metrics` endpoint is reachable through the embedded FastAPI application.
