### PR TITLE
Add configurable HTTP request logging to OpenFactoryFlaskApp

### DIFF
--- a/openfactory/apps/ofa_flask_app.py
+++ b/openfactory/apps/ofa_flask_app.py
@@ -11,8 +11,15 @@ import asyncio
 import threading
 from werkzeug.serving import make_server
 from werkzeug.middleware.proxy_fix import ProxyFix
+from werkzeug.serving import WSGIRequestHandler
 from openfactory.apps import OpenFactoryApp
 from openfactory.kafka import KSQLDBClient
+
+
+class QuietWSGIRequestHandler(WSGIRequestHandler):
+
+    def log_request(self, code="-", size="-"):
+        pass
 
 
 class OpenFactoryFlaskApp(OpenFactoryApp):
@@ -39,7 +46,7 @@ class OpenFactoryFlaskApp(OpenFactoryApp):
         - Override :meth:`create_flask_app` to customize the Flask application.
         - Override :meth:`configure_routes` to register routes or Blueprints.
         - Override :meth:`async_main_loop` to implement asynchronous background tasks.
-        - The synchronous `main_loop()` is intentionally not supported.
+        - The synchronous :meth:`OpenFactoryApp.main_loop() <openfactory.apps.ofaapp.OpenFactoryApp.main_loop>` is intentionally not supported.
 
     Attributes:
         app (flask.Flask): Flask application instance attached to the OpenFactory app.
@@ -164,6 +171,7 @@ class OpenFactoryFlaskApp(OpenFactoryApp):
 
     Note:
       - The Flask application is accessible via :attr:`app` and behaves like a standard Flask instance.
+      - HTTP access logging can be enabled or disabled using the ``log_http_requests`` constructor parameter.
       - Routes can be registered directly using :meth:`flask.Flask.route` or through Flask Blueprints (:class:`flask.Blueprint`).
       - Only asynchronous execution is supported. Subclasses should implement :meth:`async_main_loop`
         for background tasks.
@@ -192,6 +200,7 @@ class OpenFactoryFlaskApp(OpenFactoryApp):
         bootstrap_servers: str | None = None,
         asset_router_url: str | None = None,
         loglevel: str = "INFO",
+        log_http_requests: bool = True,
         test_mode: bool = False,
     ):
         """
@@ -215,6 +224,7 @@ class OpenFactoryFlaskApp(OpenFactoryApp):
             bootstrap_servers: Kafka bootstrap server address.
             asset_router_url: Asset Router URL.
             loglevel: Logging level (e.g., ``INFO``, ``DEBUG``).
+            log_http_requests: Enables logging of incoming HTTP requests handled by the embedded Flask server.
             test_mode: Enables test mode (disables live Kafka/ksql interaction).
 
         See also:
@@ -228,6 +238,8 @@ class OpenFactoryFlaskApp(OpenFactoryApp):
             loglevel=loglevel,
             test_mode=test_mode
         )
+
+        self.log_http_requests = log_http_requests
 
         # Flask application
         self.app = self.create_flask_app()
@@ -358,14 +370,18 @@ class OpenFactoryFlaskApp(OpenFactoryApp):
         variable is not set.
 
         Note:
-            This method is intended for internal use and is called automatically
-            by :meth:`async_run`.
+            - Logging of incoming HTTP requests is controlled by the
+              ``log_http_requests`` constructor parameter.
+            - This method is intended for internal use and is called automatically
+              by :meth:`async_run`.
         """
         port = int(os.getenv("PORT", "4000"))
+        handler = None if self.log_http_requests else QuietWSGIRequestHandler
         self._server = make_server(
             host="0.0.0.0",
             port=port,
-            app=self.app
+            app=self.app,
+            request_handler=handler,
         )
 
         self.logger.info(f"Starting Flask server on port {port}")

--- a/tests/openfactory/apps/test_openfactory_flask_app.py
+++ b/tests/openfactory/apps/test_openfactory_flask_app.py
@@ -2,6 +2,7 @@ import unittest
 from unittest.mock import patch, MagicMock, AsyncMock
 import asyncio
 from flask import Flask
+from openfactory.apps.ofa_flask_app import QuietWSGIRequestHandler
 
 from openfactory.apps import OpenFactoryFlaskApp
 
@@ -10,6 +11,22 @@ class _TestApp(OpenFactoryFlaskApp):
 
     async def async_main_loop(self):
         await asyncio.sleep(0.01)
+
+
+class TestQuietWSGIRequestHandler(unittest.TestCase):
+    """
+    Tests for class QuietWSGIRequestHandler
+    """
+
+    @patch("werkzeug.serving.WSGIRequestHandler.log_request")
+    def test_log_request_is_suppressed(self, mock_log_request):
+        """ QuietWSGIRequestHandler should suppress HTTP request logging. """
+
+        handler = QuietWSGIRequestHandler.__new__(QuietWSGIRequestHandler)
+
+        handler.log_request()
+
+        mock_log_request.assert_not_called()
 
 
 class TestOpenFactoryFlaskApp(unittest.TestCase):
@@ -358,6 +375,7 @@ class TestOpenFactoryFlaskAppAsync(unittest.IsolatedAsyncioTestCase):
             await asyncio.to_thread(app._run_flask)
             _, kwargs = mock_make_server.call_args
             self.assertEqual(kwargs["port"], 4000)
+            self.assertIsNone(kwargs["request_handler"])
 
     @patch("openfactory.apps.ofa_flask_app.make_server")
     async def test_run_flask_env_port(self, mock_make_server):
@@ -377,6 +395,7 @@ class TestOpenFactoryFlaskAppAsync(unittest.IsolatedAsyncioTestCase):
             await asyncio.to_thread(app._run_flask)
             _, kwargs = mock_make_server.call_args
             self.assertEqual(kwargs["port"], 5555)
+            self.assertIsNone(kwargs["request_handler"])
 
     async def test_thread_wrapper_captures_exception(self):
         """ Thread wrapper should propagate exceptions """
@@ -414,3 +433,58 @@ class TestOpenFactoryFlaskAppAsync(unittest.IsolatedAsyncioTestCase):
         await app.async_run()
 
         app.shutdown.assert_called_once()
+
+    @patch("openfactory.apps.ofa_flask_app.make_server")
+    async def test_run_flask_logs_http_requests_by_default(self, mock_make_server):
+        """ Should enable HTTP request logging by default. """
+
+        mock_make_server.return_value = MagicMock()
+
+        app = OpenFactoryFlaskApp(
+            ksqlClient=self.ksql_mock,
+            bootstrap_servers="mock",
+            asset_router_url="mock",
+        )
+
+        await asyncio.to_thread(app._run_flask)
+
+        _, kwargs = mock_make_server.call_args
+        self.assertIsNone(kwargs["request_handler"])
+
+    @patch("openfactory.apps.ofa_flask_app.make_server")
+    async def test_run_flask_disables_http_request_logging(self, mock_make_server):
+        """ Should disable HTTP request logging when requested. """
+
+        from openfactory.apps.ofa_flask_app import QuietWSGIRequestHandler
+
+        mock_make_server.return_value = MagicMock()
+
+        app = OpenFactoryFlaskApp(
+            ksqlClient=self.ksql_mock,
+            bootstrap_servers="mock",
+            asset_router_url="mock",
+            log_http_requests=False,
+        )
+
+        await asyncio.to_thread(app._run_flask)
+
+        _, kwargs = mock_make_server.call_args
+        self.assertIs(kwargs["request_handler"], QuietWSGIRequestHandler)
+
+    def test_log_http_requests_configuration(self):
+        """ Should store HTTP request logging configuration. """
+
+        app = OpenFactoryFlaskApp(
+            ksqlClient=self.ksql_mock,
+            bootstrap_servers="mock",
+            asset_router_url="mock",
+        )
+        self.assertTrue(app.log_http_requests)
+
+        app = OpenFactoryFlaskApp(
+            ksqlClient=self.ksql_mock,
+            bootstrap_servers="mock",
+            asset_router_url="mock",
+            log_http_requests=False,
+        )
+        self.assertFalse(app.log_http_requests)


### PR DESCRIPTION
## Add configurable HTTP request logging to OpenFactoryFlaskApp

### Summary

This PR adds support for enabling or disabling HTTP request logging in `OpenFactoryFlaskApp`, bringing its behavior in line with `OpenFactoryFastAPIApp`.

By default, Werkzeug continues to log incoming HTTP requests exactly as before. Applications that receive frequent health checks or operate in production environments can now disable request logging through a constructor parameter.

### Changes

#### New constructor parameter

Added a new optional constructor parameter:

```python
log_http_requests: bool = True
```

The default value preserves the existing behavior.

Example:

```python
app = OpenFactoryFlaskApp(
    ksqlClient=client,
    log_http_requests=False,
)
```

#### HTTP request logging

When `log_http_requests=False`, the embedded Werkzeug server uses a custom request handler that suppresses HTTP access logging.

This only affects HTTP request logs generated by the embedded Flask server and does not modify global logging configuration.

#### Documentation

Updated the documentation related to the new feature:

* Added `log_http_requests` to the constructor documentation.
* Updated the class documentation to mention configurable HTTP request logging.
* Updated the `_run_flask()` docstring to describe how HTTP request logging is controlled.

#### Tests

Added and updated unit tests to verify:

* HTTP request logging is enabled by default.
* HTTP request logging can be disabled through the constructor.
* The custom request handler suppresses HTTP request logging.
* Existing Flask server configuration tests were updated accordingly.

### Backward compatibility

This change is fully backward compatible.

* HTTP request logging remains enabled by default.
* Users can disable HTTP request logging when desired.
* Existing applications continue to behave unchanged.
