### PR TITLE
Delegate asset deregistration to device gateways

### DIFF
--- a/openfactory/connectors/opcua/opcua_connector.py
+++ b/openfactory/connectors/opcua/opcua_connector.py
@@ -19,7 +19,7 @@ from openfactory.connectors.base_connector import Connector
 from openfactory.assets import Asset
 from openfactory.openfactory_deploy_strategy import OpenFactoryServiceDeploymentStrategy
 from openfactory.kafka.ksql import KSQLDBClient
-from openfactory.utils import register_asset, deregister_asset
+from openfactory.utils import register_asset
 from openfactory.schemas.devices import Device
 from openfactory.schemas.connectors.opcua import OPCUAConnectorSchema
 from openfactory.exceptions import OFAException
@@ -126,12 +126,5 @@ class OPCUAConnector(Connector):
         except TypeError:
             raise OFAException(f"Asset {coordinator.asset_uuid} does not appear to be a valid OPC UA coordinator")
         user_notify.success(f"OPC UA device {device_uuid} deregistered successfully")
-
-        # De-register device asset
-        deregister_asset(
-            asset_uuid=device_uuid,
-            ksqlClient=self.ksql,
-            bootstrap_servers=self.bootstrap_servers
-        )
 
         return

--- a/openfactory/connectors/shdr/shdr_connector.py
+++ b/openfactory/connectors/shdr/shdr_connector.py
@@ -19,7 +19,7 @@ from openfactory.connectors.base_connector import Connector
 from openfactory.assets import Asset
 from openfactory.openfactory_deploy_strategy import OpenFactoryServiceDeploymentStrategy
 from openfactory.kafka.ksql import KSQLDBClient
-from openfactory.utils import register_asset, deregister_asset
+from openfactory.utils import register_asset
 from openfactory.schemas.devices import Device
 from openfactory.schemas.connectors.shdr import SHDRConnectorSchema
 from openfactory.exceptions import OFAException
@@ -130,10 +130,3 @@ class SHDRConnector(Connector):
         except TypeError:
             raise OFAException(f"Asset {coordinator.asset_uuid} does not appear to be a valid SHDR coordinator")
         user_notify.success(f"SHDR device {device_uuid} deregistered successfully")
-
-        # De-register device asset
-        deregister_asset(
-            asset_uuid=device_uuid,
-            ksqlClient=self.ksql,
-            bootstrap_servers=self.bootstrap_servers
-        )

--- a/openfactory/utils/assets.py
+++ b/openfactory/utils/assets.py
@@ -93,29 +93,6 @@ def deregister_asset(asset_uuid: str,
     """
     producer = AssetProducer(ksqlClient, bootstrap_servers)
 
-    # REMOVED message
-    producer.send_asset_attribute(
-        asset_uuid,
-        AssetAttribute(id="avail", value="REMOVED", type="Events", tag="Availability")
-    )
-    producer.flush()
-
-    # Make sure ksqlDB toloplogy did fully run
-    while True:
-        query = f"SELECT AVAILABILITY FROM assets_avail WHERE ASSET_UUID='{asset_uuid}';"
-        res = ksqlClient.query(query)
-        # res could be empty in case a none existing asset is deregistered
-        if res:
-            if res[0]['AVAILABILITY'] == "REMOVED":
-                break
-            if res[0]['AVAILABILITY'] == "UNAVAILABLE":
-                # some assets may send UNAVAILABLE
-                producer.send_asset_attribute(
-                    asset_uuid,
-                    AssetAttribute(id="avail", value="REMOVED", type="Events", tag="Availability")
-                )
-                producer.flush()
-
     # remove references
     for ref_id in ["references_below", "references_above"]:
         producer.send_asset_attribute(

--- a/tests/openfactory/connectors/opcua/test_opcua_connector.py
+++ b/tests/openfactory/connectors/opcua/test_opcua_connector.py
@@ -131,9 +131,8 @@ class TestOPCUAConnector(unittest.TestCase):
         )
 
     @patch("openfactory.connectors.opcua.opcua_connector.user_notify")
-    @patch("openfactory.connectors.opcua.opcua_connector.deregister_asset")
     @patch.object(OPCUAConnector, "_get_coordinator")
-    def test_tear_down_success(self, mock_get_coordinator, mock_deregister, mock_notify):
+    def test_tear_down_success(self, mock_get_coordinator, mock_notify):
         """ Test successful tear down. """
         coordinator = MagicMock()
         mock_get_coordinator.return_value = coordinator
@@ -145,12 +144,6 @@ class TestOPCUAConnector(unittest.TestCase):
         coordinator.deregister_device.assert_called_once_with(
             sender_uuid="opcua-connector",
             device_uuid=self.device.uuid
-        )
-
-        mock_deregister.assert_called_once_with(
-            asset_uuid=self.device.uuid,
-            ksqlClient=self.ksql_mock,
-            bootstrap_servers="kafka:9092"
         )
 
         mock_notify.success.assert_called_once_with(

--- a/tests/openfactory/connectors/shdr/test_shdr_connector.py
+++ b/tests/openfactory/connectors/shdr/test_shdr_connector.py
@@ -155,10 +155,9 @@ class TestSHDRConnector(unittest.TestCase):
 
         self.assertIn("does not appear to be a valid SHDR coordinator", str(cm.exception))
 
-    @patch("openfactory.connectors.shdr.shdr_connector.deregister_asset")
     @patch("openfactory.connectors.shdr.shdr_connector.user_notify")
     @patch.object(SHDRConnector, "_get_coordinator")
-    def test_tear_down(self, mock_get_coordinator, mock_notify, mock_deregister_asset):
+    def test_tear_down(self, mock_get_coordinator, mock_notify):
         """ Test tear_down flow. """
         mock_coordinator = MagicMock()
         mock_get_coordinator.return_value = mock_coordinator
@@ -172,13 +171,6 @@ class TestSHDRConnector(unittest.TestCase):
         mock_coordinator.deregister_device.assert_called_once_with(
             sender_uuid='shdr-connector',
             device_uuid=self.device.uuid
-        )
-
-        # Assert asset deregistration
-        mock_deregister_asset.assert_called_once_with(
-            asset_uuid=self.device.uuid,
-            ksqlClient=self.ksql_mock,
-            bootstrap_servers="kafka:9092"
         )
 
         # Assert success notification

--- a/tests/openfactory/utils/test_deregister_asset.py
+++ b/tests/openfactory/utils/test_deregister_asset.py
@@ -12,12 +12,11 @@ class TestDeregisterAsset(unittest.TestCase):
 
     @patch("openfactory.utils.assets.AssetProducer")
     def test_deregister_asset_calls_producer_correctly(self, MockAssetProducer):
-        """ Test deregister_asset logic """
+        """Test deregister_asset logic."""
 
         mock_producer_instance = MagicMock()
         MockAssetProducer.return_value = mock_producer_instance
 
-        # Inputs
         asset_uuid = "5678-EFGH"
         bootstrap_servers = "kafka-broker:9092"
 
@@ -26,52 +25,29 @@ class TestDeregisterAsset(unittest.TestCase):
             lambda table: f"topic_for_{table}"
         )
 
-        # Mock polling loop response
-        mock_ksql_client.query.return_value = [
-            {"AVAILABILITY": "REMOVED"}
-        ]
-
-        # Call function
         deregister_asset(asset_uuid, mock_ksql_client, bootstrap_servers)
 
-        # Check producer instantiation
         MockAssetProducer.assert_called_once_with(
             mock_ksql_client,
             bootstrap_servers
         )
 
-        # Check send_asset_attribute calls
         calls = mock_producer_instance.send_asset_attribute.call_args_list
 
-        # 1 REMOVED + 2 reference removals
-        self.assertEqual(len(calls), 3)
+        self.assertEqual(len(calls), 2)
 
-        # First call: REMOVED event
-        self.assertEqual(calls[0][0][0], asset_uuid)
-        self.assertIsInstance(calls[0][0][1], AssetAttribute)
-        self.assertEqual(calls[0][0][1].id, "avail")
-        self.assertEqual(calls[0][0][1].value, "REMOVED")
-        self.assertEqual(calls[0][0][1].type, "Events")
-        self.assertEqual(calls[0][0][1].tag, "Availability")
-
-        # Verify polling query happened
-        mock_ksql_client.query.assert_called_once_with(
-            f"SELECT AVAILABILITY FROM assets_avail "
-            f"WHERE ASSET_UUID='{asset_uuid}';"
-        )
-
-        # Reference cleanup messages
         expected_ids = ["references_below", "references_above"]
-        for i, ref_id in enumerate(expected_ids, start=1):
-            call = calls[i]
-            self.assertEqual(call[0][0], asset_uuid)
-            self.assertIsInstance(call[0][1], AssetAttribute)
-            self.assertEqual(call[0][1].id, ref_id)
-            self.assertEqual(call[0][1].value, "")
-            self.assertEqual(call[0][1].type, "OpenFactory")
-            self.assertEqual(call[0][1].tag, "AssetsReferences")
 
-        # Check produce tombstone messages
+        for call, ref_id in zip(calls, expected_ids):
+            self.assertEqual(call[0][0], asset_uuid)
+
+            attr = call[0][1]
+            self.assertIsInstance(attr, AssetAttribute)
+            self.assertEqual(attr.id, ref_id)
+            self.assertEqual(attr.value, "")
+            self.assertEqual(attr.type, "OpenFactory")
+            self.assertEqual(attr.tag, "AssetsReferences")
+
         expected_topics = [
             "assets_type",
             "assets_avail",
@@ -80,14 +56,14 @@ class TestDeregisterAsset(unittest.TestCase):
 
         for topic in expected_topics:
             mock_ksql_client.get_kafka_topic.assert_any_call(topic)
+
             mock_producer_instance.produce.assert_any_call(
                 topic=f"topic_for_{topic}",
                 key=asset_uuid,
                 value=None,
             )
 
-        # Ensure flush was called
-        self.assertEqual(mock_producer_instance.flush.call_count, 2)
+        mock_producer_instance.flush.assert_called_once()
 
     @patch("openfactory.utils.assets.AssetProducer")
     @patch("openfactory.utils.assets.now_iso_to_epoch_millis")
@@ -104,11 +80,6 @@ class TestDeregisterAsset(unittest.TestCase):
 
         mock_ksql_client = MagicMock()
         mock_ksql_client.get_kafka_topic.return_value = expected_topic
-
-        # Mock polling loop response
-        mock_ksql_client.query.return_value = [
-            {"AVAILABILITY": "REMOVED"}
-        ]
 
         # Call function
         deregister_asset(asset_uuid, bootstrap_servers="kafka-broker:9092", ksqlClient=mock_ksql_client)
@@ -127,88 +98,3 @@ class TestDeregisterAsset(unittest.TestCase):
                 "updated_at": 1720000000000
             })
         )
-
-    @patch("openfactory.utils.assets.AssetProducer")
-    def test_deregister_asset_waits_until_removed_state(self, MockAssetProducer):
-        """ Should keep polling until asset availability becomes REMOVED. """
-
-        mock_producer_instance = MagicMock()
-        MockAssetProducer.return_value = mock_producer_instance
-
-        asset_uuid = "5678-EFGH"
-        bootstrap_servers = "kafka-broker:9092"
-
-        mock_ksql_client = MagicMock()
-        mock_ksql_client.query.side_effect = [
-            [],
-            [],
-            [{"AVAILABILITY": "REMOVED"}]
-        ]
-
-        deregister_asset(
-            asset_uuid,
-            mock_ksql_client,
-            bootstrap_servers
-        )
-
-        self.assertEqual(mock_ksql_client.query.call_count, 3)
-
-    @patch("openfactory.utils.assets.AssetProducer")
-    def test_deregister_asset_resends_removed_when_unavailable(self, MockAssetProducer):
-        """
-        If asset reports UNAVAILABLE during deregistration,
-        deregister_asset should resend REMOVED until state becomes REMOVED.
-        """
-
-        mock_producer_instance = MagicMock()
-        MockAssetProducer.return_value = mock_producer_instance
-
-        asset_uuid = "5678-EFGH"
-        bootstrap_servers = "kafka-broker:9092"
-
-        mock_ksql_client = MagicMock()
-
-        # First poll returns UNAVAILABLE
-        # Second poll returns REMOVED
-        mock_ksql_client.query.side_effect = [
-            [{"AVAILABILITY": "UNAVAILABLE"}],
-            [{"AVAILABILITY": "REMOVED"}]
-        ]
-
-        deregister_asset(
-            asset_uuid,
-            mock_ksql_client,
-            bootstrap_servers
-        )
-
-        # Query loop should poll twice
-        self.assertEqual(mock_ksql_client.query.call_count, 2)
-
-        # REMOVED should be sent twice:
-        #   1 initial send
-        #   1 resend after UNAVAILABLE
-        avail_calls = [
-            c for c in
-            mock_producer_instance.send_asset_attribute.call_args_list
-            if c[0][1].id == "avail"
-        ]
-
-        self.assertEqual(len(avail_calls), 2)
-
-        for call in avail_calls:
-            self.assertEqual(call[0][0], asset_uuid)
-            self.assertEqual(call[0][1].value, "REMOVED")
-
-        # Total calls:
-        #   2 avail REMOVED
-        #   2 reference cleanup
-        self.assertEqual(
-            len(mock_producer_instance.send_asset_attribute.call_args_list),
-            4
-        )
-
-        # Flush calls:
-        #   1 initial REMOVED
-        #   1 resend after UNAVAILABLE
-        #   1 final flush after tombstones / UNS cleanup
-        self.assertEqual(mock_producer_instance.flush.call_count, 3)


### PR DESCRIPTION
# Delegate asset deregistration to device gateways

## Summary

This PR removes asset deregistration from the connector teardown workflow and simplifies the `deregister_asset()` implementation.

Asset lifecycle management is now expected to be owned by the device gateways rather than by the OpenFactory deployment layer.

## Motivation

Previously, connector `tear_down()` methods called `deregister_asset()`, making the deployment layer responsible for publishing the final lifecycle state of an asset.

This responsibility belongs to the gateway, which manages the device connection and is the only component that knows when a device has actually been disconnected.

With this change:

* Connectors request that gateways disconnect devices.
* Gateways are responsible for deregistering the corresponding OpenFactory asset once the device has been successfully disconnected.
* The deployment layer no longer publishes asset lifecycle events on behalf of the gateway.

## Changes

* Removed calls to `deregister_asset()` from connector `tear_down()` implementations.
* Simplified `deregister_asset()` by removing the polling and retry logic waiting for the asset to reach the `REMOVED` state.
* Updated the associated unit tests.
* Updated connector documentation to reflect the new responsibility boundaries.

## Notes

This PR changes the responsibilities within the OpenFactory repository only.

A corresponding update is required in the gateway/coordinator repositories so that they invoke `deregister_asset()` after successfully disconnecting a device.

## Benefits

* Clearer separation of responsibilities.
* Simpler connector teardown logic.
* Asset lifecycle is owned by the component managing device connectivity.
* Removal of unnecessary polling and retry logic.
