### PR TITLE
Make HTTP client recycling threshold configurable

### DIFF
--- a/openfactory/kafka/ksql.py
+++ b/openfactory/kafka/ksql.py
@@ -11,9 +11,6 @@ from openfactory.setup_logging import configure_prefixed_logger, setup_third_par
 import openfactory.config as Config
 
 
-DEFAULT_MAX_REQUESTS_PER_CONNECTION = 1000
-
-
 class KSQLDBClientException(Exception):
     """ A general error in OpenFactory. """
     pass
@@ -53,6 +50,7 @@ class KSQLDBClient:
         max_retries: int = 3,
         retry_delay: float = 2.0,
         timeout: float = 10.0,
+        max_requests_per_connection: int = 1000,
         loglevel: str = Config.KSQLDB_LOG_LEVEL,
     ):
         """
@@ -63,6 +61,7 @@ class KSQLDBClient:
             max_retries (int): Number of retry attempts on network failure. Defaults to 3.
             retry_delay (float): Seconds to wait between retries. Defaults to 2.0.
             timeout (float): Request timeout in seconds. Defaults to 10.0.
+            max_requests_per_connection (int): Number of requests to send before recreating the underlying HTTP client. Defaults to 1000.
             loglevel (str): Logging level for the client. Defaults to Config.KSQLDB_LOG_LEVEL.
         """
         self.ksqldb_url = ksqldb_url.rstrip("/")
@@ -78,7 +77,7 @@ class KSQLDBClient:
             level=loglevel)
 
         self._request_count = 0
-        self._max_requests_per_connection = DEFAULT_MAX_REQUESTS_PER_CONNECTION
+        self._max_requests_per_connection = max_requests_per_connection
 
         # single HTTP/2-only client
         self._client = self._create_client()

--- a/tests/openfactory/kafka/test_ksql.py
+++ b/tests/openfactory/kafka/test_ksql.py
@@ -35,6 +35,17 @@ class TestKSQLDBClient(unittest.TestCase):
         mock_configure_logger.assert_called_once_with("openfactory.ksqlDB", prefix="KSQL", level="MOCK_LEVEL")
         mock_logger.info.assert_called_once_with(f"Connected to ksqlDB at {ksqldb_url}")
 
+    def test_custom_max_requests_per_connection(self):
+        """ Test that a custom recycle threshold is stored. """
+
+        client = KSQLDBClient(
+            self.ksqldb_url,
+            max_requests_per_connection=42,
+        )
+
+        self.assertEqual(client._max_requests_per_connection, 42)
+        client.close()
+
     @patch("openfactory.kafka.ksql.KSQLDBClient._request")
     def test_info_success(self, mock_request):
         """ Test info method of KSQLDBClient """


### PR DESCRIPTION
# Make HTTP client recycling threshold configurable

## Summary

This pull request makes the HTTP client recycling threshold configurable by introducing a new optional `max_requests_per_connection` constructor parameter to `KSQLDBClient`.

The default behavior remains unchanged, ensuring full backward compatibility while allowing applications to tune the connection lifetime for different workloads.

## Changes

* Added an optional `max_requests_per_connection` parameter to `KSQLDBClient`.
* Default value is `1000`, preserving the existing behavior.
* Replaced the previously hardcoded recycling threshold with the configurable constructor parameter.
* Updated the constructor documentation to describe the new parameter.
* Added a unit test verifying that a custom threshold is correctly stored by the client.

## Benefits

* Enables applications to tune HTTP client recycling without modifying library code.
* Preserves the existing default behavior for all current users.
* Improves flexibility for different deployment environments and workloads.
* Keeps the API simple and intuitive.

## Testing

* Existing unit tests continue to pass.
* Added a unit test covering the new constructor parameter.
* Verified that the HTTP client recycling logic continues to behave as before when the default value is used.
