### PR TITLE
Fix OpenFactory Apps incorrectly reporting as UNAVAILABLE

### DIFF
--- a/openfactory/apps/ofa_fastapi_app.py
+++ b/openfactory/apps/ofa_fastapi_app.py
@@ -6,6 +6,7 @@ from fastapi import Response
 from prometheus_client import CONTENT_TYPE_LATEST, REGISTRY, CollectorRegistry, generate_latest
 from openfactory.kafka import KSQLDBClient
 from openfactory.apps import OpenFactoryApp
+from openfactory.assets import AssetAttribute
 
 try:
     from fastapi import FastAPI
@@ -408,7 +409,13 @@ class OpenFactoryFastAPIApp(OpenFactoryApp):
         """
 
         self.welcome_banner()
-        self.avail = 'AVAILABLE'
+        if not self._test_mode:
+            self.producer.send_asset_attribute(
+                asset_uuid=self.asset_uuid,
+                assetAttribute=AssetAttribute(
+                    id='avail', value='AVAILABLE', tag='Availability', type='Events'
+                )
+            )
         self.logger.info("Starting async main loop")
 
         task_fastapi = asyncio.create_task(self._run_fastapi(), name="FastAPI")

--- a/openfactory/apps/ofa_flask_app.py
+++ b/openfactory/apps/ofa_flask_app.py
@@ -14,6 +14,7 @@ from werkzeug.middleware.proxy_fix import ProxyFix
 from werkzeug.serving import WSGIRequestHandler
 from openfactory.apps import OpenFactoryApp
 from openfactory.kafka import KSQLDBClient
+from openfactory.assets import AssetAttribute
 
 
 class QuietWSGIRequestHandler(WSGIRequestHandler):
@@ -453,7 +454,13 @@ class OpenFactoryFlaskApp(OpenFactoryApp):
                 triggers :meth:`OpenFactoryApp.app_event_loop_stopped() <openfactory.apps.ofaapp.OpenFactoryApp.app_event_loop_stopped>`.
         """
         self.welcome_banner()
-        self.avail = "AVAILABLE"
+        if not self._test_mode:
+            self.producer.send_asset_attribute(
+                asset_uuid=self.asset_uuid,
+                assetAttribute=AssetAttribute(
+                    id='avail', value='AVAILABLE', tag='Availability', type='Events'
+                )
+            )
 
         flask_thread = threading.Thread(
             target=lambda: self._thread_wrapper(self._run_flask),

--- a/openfactory/apps/ofaapp.py
+++ b/openfactory/apps/ofaapp.py
@@ -439,7 +439,13 @@ class OpenFactoryApp(Asset, metaclass=OpenFactoryAppMeta):
             Exception: If any exception occurs during the execution of the main loop, it is caught and logged, and the app is stopped.
         """
         self.welcome_banner()
-        self.avail = 'AVAILABLE'
+        if not self._test_mode:
+            self.producer.send_asset_attribute(
+                asset_uuid=self.asset_uuid,
+                assetAttribute=AssetAttribute(
+                    id='avail', value='AVAILABLE', tag='Availability', type='Events'
+                )
+            )
         self.logger.info("Starting main loop")
         try:
             self.main_loop()
@@ -486,7 +492,12 @@ class OpenFactoryApp(Asset, metaclass=OpenFactoryAppMeta):
             Exception: Any exception raised by :meth:`async_main_loop` is caught, logged, and triggers a graceful shutdown.
         """
         self.welcome_banner()
-        self.avail = 'AVAILABLE'
+        if not self._test_mode:
+            self.producer.send_asset_attribute(
+                AssetAttribute(
+                    id='avail', value='AVAILABLE', tag='Availability', type='Events'
+                )
+            )
         self.logger.info("Starting async main loop")
         try:
             await self.async_main_loop()

--- a/tests/openfactory/apps/test_openfactoryapp.py
+++ b/tests/openfactory/apps/test_openfactoryapp.py
@@ -453,9 +453,6 @@ class TestOpenFactoryAppAsync(unittest.IsolatedAsyncioTestCase):
         # Check welcome banner called
         mock_banner.assert_called_once()
 
-        # Check that add_attribute was called with an AssetAttribute
-        self.assertEqual(app.avail, 'AVAILABLE')
-
         # Check async_main_loop executed
         app.async_main_loop.assert_awaited_once()
 


### PR DESCRIPTION
## Fix OpenFactory Apps incorrectly reporting as `UNAVAILABLE`

### Summary

This PR fixes an issue where OpenFactory Apps could be reported as `UNAVAILABLE` even though they were running correctly.

### Changes

Availability is now reported by sending the availability message directly to Kafka instead of relying on:

```python
self.avail = 'AVAILABLE'
```

This avoids a timing issue where the `avail` Asset Attribute may not yet be recognized by ksqlDB, preventing the corresponding Kafka message from being generated.

### Result

OpenFactory Apps now reliably report their availability regardless of whether the `avail` Asset Attribute has already been recognized by ksqlDB.
