### PR TITLE
Add wait_to_become_available option to BaseAsset.add_attribute()

### DIFF
--- a/openfactory/assets/asset_base.py
+++ b/openfactory/assets/asset_base.py
@@ -564,18 +564,21 @@ class BaseAsset:
                 type=attr.type)
             )
 
-    def add_attribute(self, asset_attribute: AssetAttribute) -> None:
+    def add_attribute(self, asset_attribute: AssetAttribute, wait_to_become_available: bool = True) -> None:
         """
         Adds a new attribute to the asset.
 
         Args:
             asset_attribute (AssetAttribute): The attribute to be added.
+            wait_to_become_available (bool): If true, will wait until the Attribute is available in ksqlDB
         """
         if getattr(self, "_test_mode", False):
             # add to internal mock list
             self._mocked_attributes.append(asset_attribute)
             return
         self.producer.send_asset_attribute(self.asset_uuid, asset_attribute)
+        if wait_to_become_available:
+            self.wait_until(attribute_id=asset_attribute.id, value=asset_attribute.value, use_ksqlDB=True)
 
     def _get_reference_list(self, direction: str, as_assets: bool = False) -> List[str | Self]:
         """
@@ -695,7 +698,13 @@ class BaseAsset:
             bool: `True` if the attribute value matches the expected value within the timeout, `False` otherwise.
         """
         # First, check the current attribute value
-        if self.__getattr__(attribute_id).value == value:
+        attribute = self.__getattr__(attribute_id)
+        if type(attribute) is AssetAttribute:
+            if attribute.value == value:
+                return True
+
+        # If an OpenFactory method, wait_until is not applicable
+        if callable(attribute):
             return True
 
         start_time = time.time()

--- a/tests/openfactory/apps/test_openfactory_fastapi_app.py
+++ b/tests/openfactory/apps/test_openfactory_fastapi_app.py
@@ -22,6 +22,10 @@ class TestOpenFactoryFastAPIApp(unittest.TestCase):
         self.asset_producer_patcher.start()
         self.addCleanup(self.asset_producer_patcher.stop)
 
+        self.wait_until_patcher = patch("openfactory.assets.asset_base.BaseAsset.wait_until", return_value=True)
+        self.wait_until_patcher.start()
+        self.addCleanup(self.wait_until_patcher.stop)
+
         self.deregister_patcher = patch('openfactory.apps.ofaapp.deregister_asset')
         self.deregister_patcher.start()
         self.addCleanup(self.deregister_patcher.stop)
@@ -125,6 +129,10 @@ class TestOpenFactoryFastAPIAppAsync(unittest.IsolatedAsyncioTestCase):
         self.asset_producer_patcher = patch("openfactory.assets.asset_base.AssetProducer")
         self.asset_producer_patcher.start()
         self.addCleanup(self.asset_producer_patcher.stop)
+
+        self.wait_until_patcher = patch("openfactory.assets.asset_base.BaseAsset.wait_until", return_value=True)
+        self.wait_until_patcher.start()
+        self.addCleanup(self.wait_until_patcher.stop)
 
         self.deregister_patcher = patch('openfactory.apps.ofaapp.deregister_asset')
         self.deregister_patcher.start()

--- a/tests/openfactory/apps/test_openfactory_flask_app.py
+++ b/tests/openfactory/apps/test_openfactory_flask_app.py
@@ -38,15 +38,15 @@ class TestOpenFactoryFlaskApp(unittest.TestCase):
 
         self.ksql_mock = MagicMock()
 
-        self.asset_producer_patcher = patch(
-            "openfactory.assets.asset_base.AssetProducer"
-        )
+        self.asset_producer_patcher = patch("openfactory.assets.asset_base.AssetProducer")
         self.asset_producer_patcher.start()
         self.addCleanup(self.asset_producer_patcher.stop)
 
-        self.deregister_patcher = patch(
-            "openfactory.apps.ofaapp.deregister_asset"
-        )
+        self.wait_until_patcher = patch("openfactory.assets.asset_base.BaseAsset.wait_until", return_value=True)
+        self.wait_until_patcher.start()
+        self.addCleanup(self.wait_until_patcher.stop)
+
+        self.deregister_patcher = patch("openfactory.apps.ofaapp.deregister_asset")
         self.deregister_patcher.start()
         self.addCleanup(self.deregister_patcher.stop)
 
@@ -235,15 +235,15 @@ class TestOpenFactoryFlaskAppAsync(unittest.IsolatedAsyncioTestCase):
 
         self.ksql_mock = MagicMock()
 
-        self.asset_producer_patcher = patch(
-            "openfactory.assets.asset_base.AssetProducer"
-        )
+        self.asset_producer_patcher = patch("openfactory.assets.asset_base.AssetProducer")
         self.asset_producer_patcher.start()
         self.addCleanup(self.asset_producer_patcher.stop)
 
-        self.deregister_patcher = patch(
-            "openfactory.apps.ofaapp.deregister_asset"
-        )
+        self.wait_until_patcher = patch("openfactory.assets.asset_base.BaseAsset.wait_until", return_value=True)
+        self.wait_until_patcher.start()
+        self.addCleanup(self.wait_until_patcher.stop)
+
+        self.deregister_patcher = patch("openfactory.apps.ofaapp.deregister_asset")
         self.deregister_patcher.start()
         self.addCleanup(self.deregister_patcher.stop)
 

--- a/tests/openfactory/apps/test_openfactory_flask_app_http.py
+++ b/tests/openfactory/apps/test_openfactory_flask_app_http.py
@@ -39,17 +39,17 @@ class TestOpenFactoryFlaskAppHTTP(unittest.TestCase):
 
         self.ksql_mock = MagicMock()
 
-        self.asset_producer_patcher = patch(
-            "openfactory.assets.asset_base.AssetProducer"
-        )
+        self.asset_producer_patcher = patch("openfactory.assets.asset_base.AssetProducer")
         self.asset_producer_patcher.start()
         self.addCleanup(self.asset_producer_patcher.stop)
 
-        self.deregister_patcher = patch(
-            "openfactory.apps.ofaapp.deregister_asset"
-        )
+        self.deregister_patcher = patch("openfactory.apps.ofaapp.deregister_asset")
         self.deregister_patcher.start()
         self.addCleanup(self.deregister_patcher.stop)
+
+        self.wait_until_patcher = patch("openfactory.assets.asset_base.BaseAsset.wait_until", return_value=True)
+        self.wait_until_patcher.start()
+        self.addCleanup(self.wait_until_patcher.stop)
 
         self.app = _HTTPTestApp(
             ksqlClient=self.ksql_mock,

--- a/tests/openfactory/apps/test_openfactoryapp.py
+++ b/tests/openfactory/apps/test_openfactoryapp.py
@@ -24,6 +24,11 @@ class TestOpenFactoryApp(unittest.TestCase):
         self.MockAssetProducer = self.asset_producer_patcher.start()
         self.addCleanup(self.asset_producer_patcher.stop)
 
+        # Patch wait_until
+        self.wait_until_patcher = patch("openfactory.assets.asset_base.BaseAsset.wait_until", return_value=True)
+        self.mock_wait_until = self.wait_until_patcher.start()
+        self.addCleanup(self.wait_until_patcher.stop)
+
         # Patch deregister_asset
         self.deregister_patcher = patch('openfactory.apps.ofaapp.deregister_asset')
         self.mock_deregister = self.deregister_patcher.start()

--- a/tests/openfactory/apps/test_openfactoryapp_declarative_attributes.py
+++ b/tests/openfactory/apps/test_openfactoryapp_declarative_attributes.py
@@ -42,6 +42,11 @@ class TestDeclarativeAttributes(unittest.TestCase):
         self.MockAssetProducer = self.asset_producer_patcher.start()
         self.addCleanup(self.asset_producer_patcher.stop)
 
+        # Patch wait_until
+        self.wait_until_patcher = patch("openfactory.assets.asset_base.BaseAsset.wait_until", return_value=True)
+        self.wait_until_patcher.start()
+        self.addCleanup(self.wait_until_patcher.stop)
+
         self.app = TestApp(ksqlClient=self.ksql_mock, bootstrap_servers="mocked_broker", asset_router_url="mocked_url")
 
     def test_declared_attributes_collection(self):

--- a/tests/openfactory/assets/test_baseasset.py
+++ b/tests/openfactory/assets/test_baseasset.py
@@ -558,6 +558,73 @@ class TestBaseAsset(TestCase):
         expected_query = "SELECT VALUE, TYPE, TAG, TIMESTAMP FROM assets WHERE key='uuid-123|a_method';"
         ksqlMock.query.assert_any_call(expected_query)
 
+    def test_add_attribute_sends_asset_attribute(self, MockAssetProducer):
+        """ Test add_attribute sends the new AssetAttribute to the producer """
+        asset = ValidAsset("uuid-123", ksqlClient=MagicMock())
+        asset.wait_until = MagicMock(return_value=True)
+        attr = AssetAttribute(
+            id="temperature",
+            value=42,
+            type="Samples",
+            tag="Temperature",
+        )
+
+        asset.add_attribute(attr)
+
+        asset.producer.send_asset_attribute.assert_called_once_with("uuid-123", attr)
+
+    def test_add_attribute_in_test_mode_adds_to_mocked_attributes(self, MockAssetProducer):
+        """ Test add_attribute stores the attribute locally when in test mode """
+        asset = ValidAsset.__new__(ValidAsset)
+        BaseAsset.__init__(asset, ksqlClient=MagicMock(), test_mode=True)
+
+        attr = AssetAttribute(
+            id="temperature",
+            value=42,
+            type="Samples",
+            tag="Temperature",
+        )
+
+        asset.add_attribute(attr)
+
+        self.assertIn(attr, asset._mocked_attributes)
+
+    def test_add_attribute_waits_until_available_by_default(self, MockAssetProducer):
+        """ Test add_attribute waits until the new attribute is available by default """
+        asset = ValidAsset("uuid-123", ksqlClient=MagicMock())
+        asset.wait_until = MagicMock(return_value=True)
+        attr = AssetAttribute(
+            id="temperature",
+            value=42,
+            type="Samples",
+            tag="Temperature",
+        )
+
+        asset.add_attribute(attr)
+
+        asset.producer.send_asset_attribute.assert_called_once_with("uuid-123", attr)
+        asset.wait_until.assert_called_once_with(
+            attribute_id="temperature",
+            value=42,
+            use_ksqlDB=True,
+        )
+
+    def test_add_attribute_does_not_wait_when_disabled(self, MockAssetProducer):
+        """ Test add_attribute does not wait when wait_to_become_available=False """
+        asset = ValidAsset("uuid-123", ksqlClient=MagicMock())
+        asset.wait_until = MagicMock()
+        attr = AssetAttribute(
+            id="temperature",
+            value=42,
+            type="Samples",
+            tag="Temperature",
+        )
+
+        asset.add_attribute(attr, wait_to_become_available=False)
+
+        asset.producer.send_asset_attribute.assert_called_once_with("uuid-123", attr)
+        asset.wait_until.assert_not_called()
+
     def test_get_reference_list_not_implemented(self, MockAssetProducer):
         """ Test if _get_reference_list raises NotImplementedError when not implemented in subclass """
 
@@ -748,9 +815,13 @@ class TestBaseAsset(TestCase):
         attribute_id = "test_attribute"
         expected_value = 42
 
-        # Mock __getattr__ to return a dummy attribute initially
-        mock_attribute = MagicMock()
-        mock_attribute.value = "not_expected_value"
+        # Mock __getattr__ to return an initially non-matching asset attribute
+        mock_attribute = AssetAttribute(
+            id=attribute_id,
+            value="not_expected_value",
+            type="Samples",
+            tag="TestAttribute",
+        )
         asset.__getattr__ = MagicMock(return_value=mock_attribute)
 
         # Patch the NATS consumer start/stop
@@ -778,9 +849,13 @@ class TestBaseAsset(TestCase):
         attribute_id = "temperature"
         expected_value = 42.0
 
-        # Mock __getattr__ to simulate initial mismatch
-        mock_attribute = MagicMock()
-        mock_attribute.value = "not_expected_value"
+        # Mock __getattr__ to return an initially non-matching asset attribute
+        mock_attribute = AssetAttribute(
+            id=attribute_id,
+            value=10.0,
+            type="Samples",
+            tag="Temperature",
+        )
         asset.__getattr__ = MagicMock(return_value=mock_attribute)
 
         # Patch NATS start/stop
@@ -810,7 +885,13 @@ class TestBaseAsset(TestCase):
     def test_wait_until_ksqldb_timeout(self, MockAssetProducer):
         """ Test wait_until with use_ksqlDB=True returns False after timeout when no match is found """
         asset = ValidAsset("test_uuid", ksqlClient=MagicMock())
-        asset.__getattr__ = MagicMock(return_value=MagicMock(value="initial"))
+        mock_attribute = AssetAttribute(
+            id="test_attribute",
+            value="initial",
+            type="Events",
+            tag="TestAttribute",
+        )
+        asset.__getattr__ = MagicMock(return_value=mock_attribute)
 
         # Test timeout when use_ksqlDB is True
         result = asset.wait_until(attribute_id="test_attribute", value="target", timeout=1, use_ksqlDB=True)


### PR DESCRIPTION
# Add `wait_to_become_available` option to `BaseAsset.add_attribute()`

## Description

This PR adds a `wait_to_become_available` option to `BaseAsset.add_attribute()`.

Asset attributes are published asynchronously. Code that adds an attribute may therefore continue before the newly added attribute is available through the OpenFactory state in ksqlDB.

With this change, `add_attribute()` waits by default until the newly added attribute and its value are available before returning.

Waiting can be disabled explicitly for use cases where synchronization is not required.

## Changes

### `BaseAsset.add_attribute()`

Adds the new optional argument:

```python
wait_to_become_available: bool = True
```

When enabled, `add_attribute()` waits for the newly published attribute using:

```python
self.wait_until(
    attribute_id=asset_attribute.id,
    value=asset_attribute.value,
    use_ksqlDB=True,
)
```

Waiting can be disabled when immediate return is desired:

```python
asset.add_attribute(
    asset_attribute,
    wait_to_become_available=False,
)
```

Test mode behavior remains unchanged: attributes are added directly to the internal mocked attribute collection without publishing or waiting.

### `BaseAsset.wait_until()`

Improves handling of callable attributes so that `wait_until()` does not attempt to wait for OpenFactory methods.

### Tests

Adds unit test coverage for `add_attribute()` covering:

* Publishing an `AssetAttribute` through the asset producer.
* Waiting for the attribute to become available by default.
* Skipping the wait when `wait_to_become_available=False`.

Existing `wait_until()` tests were updated to use actual `AssetAttribute` instances instead of callable `MagicMock` objects where an asset attribute is expected.

Application-level test suites were also updated to mock `BaseAsset.wait_until()` where application initialization is not intended to test ksqlDB synchronization.

## Behavior

Default behavior:

```python
asset.add_attribute(attribute)
```

publishes the attribute and waits until it becomes available.

For asynchronous/fire-and-forget behavior:

```python
asset.add_attribute(
    attribute,
    wait_to_become_available=False,
)
```

publishes the attribute and returns without waiting.
