### PR TITLE
Replace MD5 with SHA-256 in ConsistentHashRing

### DIFF
--- a/openfactory/fanoutlayer/utils/hash_ring.py
+++ b/openfactory/fanoutlayer/utils/hash_ring.py
@@ -5,7 +5,7 @@ Consistent Hash Ring
 This module provides the ``ConsistentHashRing`` class, which maps arbitrary
 keys (e.g., asset UUIDs) to nodes (e.g., NATS clusters) using consistent hashing.
 
-It uses MD5 hashing and virtual nodes to:
+It uses SHA-256 hashing and virtual nodes to:
 
 - Ensure an even distribution of keys across nodes.
 - Minimize key reassignment when nodes are added or removed.
@@ -29,6 +29,7 @@ Features
 """
 
 import hashlib
+import bisect
 from typing import Dict, List
 
 
@@ -36,7 +37,7 @@ class ConsistentHashRing:
     """
     Consistent Hash Ring for mapping keys to nodes.
 
-    This implementation uses MD5 hashing and virtual nodes to distribute keys
+    This implementation uses SHA-256 hashing and virtual nodes to distribute keys
     evenly across a set of nodes. It ensures that each key is always mapped to
     the same node unless the set of nodes changes, and minimizes reassignments
     when nodes are added or removed.
@@ -68,11 +69,17 @@ class ConsistentHashRing:
         for node in nodes:
             for r in range(replicas):
                 vnode_key = f"{node}::{r}".encode()
-                h = int(hashlib.md5(vnode_key).hexdigest(), 16)
+                h = self._hash(vnode_key)
+
                 self._ring[h] = node
                 self._sorted_keys.append(h)
 
         self._sorted_keys.sort()
+
+    @staticmethod
+    def _hash(key: bytes) -> int:
+        """ Return a deterministic integer hash for ring positioning. """
+        return int.from_bytes(hashlib.sha256(key).digest(), byteorder="big")
 
     def get(self, key: bytes) -> str:
         """
@@ -84,12 +91,10 @@ class ConsistentHashRing:
         Returns:
             str: The node identifier that the key maps to.
         """
-        import bisect
-
         if not isinstance(key, (bytes, bytearray)):
             key = str(key).encode()
 
-        h = int(hashlib.md5(key).hexdigest(), 16)
+        h = self._hash(key)
         idx = bisect.bisect(self._sorted_keys, h)
         if idx == len(self._sorted_keys):
             idx = 0

--- a/tests/openfactory/fanoutlayer/utils/test_hash_ring.py
+++ b/tests/openfactory/fanoutlayer/utils/test_hash_ring.py
@@ -1,4 +1,6 @@
+import hashlib
 import unittest
+from unittest.mock import patch
 from openfactory.fanoutlayer import ConsistentHashRing
 
 
@@ -24,8 +26,19 @@ class TestConsistentHashRing(unittest.TestCase):
         self.assertEqual(len(self.ring._sorted_keys), expected_vnodes)
 
     def test_sorted_keys_are_sorted(self):
-        """ Test that the ring’s sorted keys are in ascending order. """
+        """ Test that the ring's sorted keys are in ascending order. """
         self.assertEqual(sorted(self.ring._sorted_keys), self.ring._sorted_keys)
+
+    def test_hash_uses_sha256(self):
+        """ Test that ring positions are computed using SHA-256. """
+        key = b"test-key"
+
+        expected = int.from_bytes(
+            hashlib.sha256(key).digest(),
+            byteorder="big",
+        )
+
+        self.assertEqual(ConsistentHashRing._hash(key), expected)
 
     def test_get_returns_node_from_list(self):
         """ Test that get() always returns a node from the provided list. """
@@ -41,35 +54,52 @@ class TestConsistentHashRing(unittest.TestCase):
         self.assertEqual(node1, node2)
 
     def test_get_wraps_around_ring(self):
-        """ Test that when hash > max vnode, lookup wraps to first node. """
-        import bisect
-
-        # Force idx to be len(sorted_keys), simulating wrap-around
-        idx = bisect.bisect(self.ring._sorted_keys, max(self.ring._sorted_keys))
-        self.assertEqual(idx, len(self.ring._sorted_keys))
-
-        # In wrap-around case, get() should return first node
+        """ Test that a hash beyond the last vnode wraps to the first vnode. """
+        hash_beyond_ring = self.ring._sorted_keys[-1] + 1
         expected_node = self.ring._ring[self.ring._sorted_keys[0]]
 
-        # Manually simulate the wrap-around
-        wrapped_idx = 0
-        actual_node = self.ring._ring[self.ring._sorted_keys[wrapped_idx]]
+        with patch.object(ConsistentHashRing, "_hash", return_value=hash_beyond_ring):
+            actual_node = self.ring.get(b"any-key")
 
         self.assertEqual(actual_node, expected_node)
 
     def test_reassignment_minimized_when_adding_node(self):
-        """ Test that adding a node only reassigns keys if necessary. """
+        """ Test that adding a node only reassigns keys to the new node. """
         key = b"customer123"
         old_node = self.ring.get(key)
 
-        # Add a new node and reinitialize
         new_nodes = self.nodes + ["node4"]
         new_ring = ConsistentHashRing(new_nodes, replicas=10)
         new_node = new_ring.get(key)
 
         self.assertIn(new_node, new_nodes)
+
         if new_node != old_node:
             self.assertEqual(new_node, "node4")
+
+    def test_adding_node_only_reassigns_keys_to_new_node(self):
+        """ Test across many keys that reassignments only target the new node. """
+        keys = [f"key-{i}".encode() for i in range(1000)]
+
+        old_assignments = {
+            key: self.ring.get(key)
+            for key in keys
+        }
+
+        new_nodes = self.nodes + ["node4"]
+        new_ring = ConsistentHashRing(new_nodes, replicas=10)
+
+        reassigned = 0
+
+        for key in keys:
+            old_node = old_assignments[key]
+            new_node = new_ring.get(key)
+
+            if new_node != old_node:
+                reassigned += 1
+                self.assertEqual(new_node, "node4")
+
+        self.assertGreater(reassigned, 0)
 
     def test_get_accepts_non_bytes_input(self):
         """ Test that get() accepts str and int keys in addition to bytes. """


### PR DESCRIPTION
# Replace MD5 with SHA-256 in ConsistentHashRing

## Summary

This PR replaces MD5 with SHA-256 in `ConsistentHashRing`.

MD5 was used exclusively for non-cryptographic consistent hashing, but its use is flagged by GitHub CodeQL as a weak cryptographic hash function.

Hash computation is now centralized in `_hash()` and uses SHA-256 for both virtual-node and asset-key positioning.

## Changes

- Replace MD5 with SHA-256 for consistent hashing.
- Centralize hash computation in `ConsistentHashRing._hash()`.
- Update documentation to reflect the use of SHA-256.
- Add a test verifying that SHA-256 is used for ring positioning.
- Improve the wrap-around test to exercise `ConsistentHashRing.get()` directly.
- Add coverage across multiple keys to verify that adding a node only reassigns keys to the newly added node.

## Breaking change

Changing the hash function changes the positions of both virtual nodes and asset keys on the consistent hash ring.

As a result, existing assets may map to different NATS clusters after upgrading. Existing asset deployments are therefore not compatible across this change.

### Upgrade procedure

Before upgrading:

1. Tear down all currently deployed assets using the existing OpenFactory version.
2. Upgrade OpenFactory.
3. Redeploy all assets.

Redeploying the assets establishes their routing using the new SHA-256-based consistent hash ring.
