### PR TITLE
Fix instance access for declarative attributes

### DIFF
--- a/openfactory/apps/attributefield.py
+++ b/openfactory/apps/attributefield.py
@@ -31,6 +31,12 @@ class AttributeField:
         self.tag = tag
         self.name = None  # will be set by metaclass
 
+    def __get__(self, instance, owner):
+        if instance is None:
+            return self
+
+        return instance.__getattr__(self.name)
+
 
 class EventAttribute(AttributeField):
     """

--- a/tests/openfactory/apps/test_openfactoryapp_declarative_attributes.py
+++ b/tests/openfactory/apps/test_openfactoryapp_declarative_attributes.py
@@ -95,3 +95,45 @@ class TestDeclarativeAttributes(unittest.TestCase):
             self.assertEqual(asset_dict["temp"].value, "UNAVAILABLE")
             self.assertEqual(asset_dict["temp"].tag, "Temperature")
             self.assertEqual(asset_dict["temp"].type, "Samples")
+
+    def test_attribute_access_from_class_returns_descriptor(self):
+        """ Check that class access returns the declared attribute descriptor itself. """
+        self.assertIs(TestApp.app_version, TestApp._declared_attributes["app_version"])
+        self.assertIs(TestApp.license_type, TestApp._declared_attributes["license_type"])
+        self.assertIs(TestApp.sample_rate, TestApp._declared_attributes["sample_rate"])
+        self.assertIs(TestApp.temp, TestApp._declared_attributes["temp"])
+
+        self.assertIsInstance(TestApp.app_version, EventAttribute)
+        self.assertIsInstance(TestApp.license_type, EventAttribute)
+        self.assertIsInstance(TestApp.sample_rate, SampleAttribute)
+        self.assertIsInstance(TestApp.temp, SampleAttribute)
+
+    def test_attribute_access_from_instance_delegates_to_getattr(self):
+        """ Check that accessing declarative attributes delegates to __getattr__. """
+        with patch.object(TestApp, "__getattr__", autospec=True) as mock_getattr:
+            mock_getattr.side_effect = lambda instance, name: f"value-for-{name}"
+
+            self.assertEqual(self.app.app_version, "value-for-app_version")
+            self.assertEqual(self.app.license_type, "value-for-license_type")
+            self.assertEqual(self.app.sample_rate, "value-for-sample_rate")
+            self.assertEqual(self.app.temp, "value-for-temp")
+
+            self.assertEqual(
+                [call.args[1] for call in mock_getattr.call_args_list],
+                ["app_version", "license_type", "sample_rate", "temp"],
+            )
+
+    def test_descriptor_names_are_set_by_metaclass(self):
+        """ Check that the metaclass assigns the declared attribute name to each descriptor. """
+        self.assertEqual(TestApp.app_version.name, "app_version")
+        self.assertEqual(TestApp.license_type.name, "license_type")
+        self.assertEqual(TestApp.sample_rate.name, "sample_rate")
+        self.assertEqual(TestApp.temp.name, "temp")
+
+    def test_declarative_attribute_instance_access_delegates_to_getattr(self):
+        """ Access through an instance delegates to __getattr__. """
+        with patch.object(TestApp, "__getattr__", return_value="resolved") as mock_getattr:
+            result = self.app.temp
+
+            mock_getattr.assert_called_once_with("temp")
+            self.assertEqual(result, "resolved")


### PR DESCRIPTION
# Fix instance access for declarative attributes

## Description

This PR fixes instance access to declarative OpenFactory attributes.

Declarative attributes such as:

```python
class DemoApp(OpenFactoryApp):
    status = EventAttribute(value="idle", tag="App.Status")
    temperature = SampleAttribute(tag="Temperature")
```

are defined as class attributes. Because of this, accessing:

```python
self.temperature
```

previously returned the `SampleAttribute` declaration itself. Python found the attribute on the class and therefore never invoked `OpenFactoryApp.__getattr__()`, bypassing the dynamic OpenFactory asset lookup.

As a consequence, expressions such as:

```python
self.temperature.value
```

returned the value stored in the declarative field rather than the current value resolved through OpenFactory.

## Changes

`AttributeField` now implements the descriptor protocol through `__get__`:

```python
def __get__(self, instance, owner):
    if instance is None:
        return self

    return instance.__getattr__(self.name)
```

This preserves both required access patterns:

```python
DemoApp.temperature
# -> SampleAttribute declaration

app.temperature
# -> resolved through app.__getattr__("temperature")
```

Instance access therefore uses the existing OpenFactory asset lookup mechanism, while class-level access continues to expose the declarative field definition.

## Tests

Added tests to verify that:

* Class-level access returns the original declarative `AttributeField`.
* Instance-level access delegates to `OpenFactoryApp.__getattr__()`.
* Instance-level access returns the dynamically resolved attribute instead of the static declarative field.
