### PR TITLE
Introduce a stateful BaseAsset synchronized by NATS

### DIFF
--- a/openfactory/assets/asset_base.py
+++ b/openfactory/assets/asset_base.py
@@ -5,11 +5,11 @@ import os
 import json
 import re
 import time
-import uuid
 import threading
 import asyncio
+from operator import eq
 from uuid import uuid4
-from typing import Literal, List, Dict, Any, Callable, Self, Tuple, Optional
+from typing import Literal, List, Dict, Any, Callable, Self
 from openfactory.exceptions import OFAException
 from openfactory.kafka import KSQLDBClient, KafkaAssetConsumer, KafkaAssetUNSConsumer, AssetProducer, CaseInsensitiveDict
 from openfactory.assets.utils import AssetAttribute, AssetNATSCallback, AsyncLoopThread, NATSSubscriber, get_nats_cluster_url
@@ -21,7 +21,7 @@ class BaseAsset:
     Base class for OpenFactory Assets.
 
     Warning:
-        This is an abstract class not intented to be used.
+        This is an abstract base class and should not be instantiated directly.
         From this class, two classes are derived (:class:`Asset <openfactory.assets.asset_class.Asset>`
         and :class:`AssetUNS <openfactory.assets.asset_uns_class.AssetUNS>`) for actual usage.
 
@@ -30,7 +30,7 @@ class BaseAsset:
 
     Note:
         - All write operations to the asset take place in the ``assets`` stream.
-        - NATS subscribers allow filtering messages by TYPE (``Samples``, ``Events``, ``Condition``).
+        - A single NATS subscriber keeps the asset state synchronized and dispatches registered callbacks.
 
     Attributes:
         KSQL_ASSET_TABLE (str): Name of ksqlDB table of asset states (``assets`` or ``assets_uns``).
@@ -42,7 +42,15 @@ class BaseAsset:
         ASSET_CONSUMER_CLASS (KafkaAssetConsumer|KafkaAssetUNSConsumer): Kafka consumer class for reading messages from asset stream.
         producer (AssetProducer): Shared Kafka producer instance used to publish asset messages (singleton across all BaseAsset subclasses).
         loop_thread (AsyncLoopThread): Async event loop thread used for NATS subscriptions.
-        subscribers (dict): Mapping of subscription keys to NATSSubscriber instances.
+        ofa_attributes (Dict[str, AssetAttribute]): Dictionary mapping attribute IDs to their current AssetAttribute.
+        ofa_methods (Dict[str, dict | None]): Dictionary mapping method IDs to their parsed method contracts.
+        _condition (threading.Condition): Condition variable used by wait_until() to wait for attribute updates.
+        _subscriber (NATSSubscriber): Permanent NATS subscriber responsible for synchronizing the internal state.
+        _attribute_callbacks (Dict[str, AssetNATSCallback]): Registered callbacks invoked when a specific attribute changes.
+        _messages_callback (AssetNATSCallback | None): Callback invoked for every received asset message.
+        _samples_callback (AssetNATSCallback | None): Callback invoked for every received sample message.
+        _events_callback (AssetNATSCallback | None): Callback invoked for every received event message.
+        _conditions_callback (AssetNATSCallback | None): Callback invoked for every received condition message.
     """
 
     # Instance attributes
@@ -51,7 +59,6 @@ class BaseAsset:
     asset_router_url: str | None
     producer: AssetProducer | None
     loop_thread: AsyncLoopThread | None
-    subscribers: dict[str, NATSSubscriber]
 
     _test_mode: bool
     _mocked_attributes: list[str]
@@ -94,17 +101,23 @@ class BaseAsset:
           - If ``asset_router_url`` is not explicitly provided, the constructor will attempt to read it from the ``ASSET_ROUTER_URL`` environment variable.
           - When used in an :class:`OpenFactoryApp <openfactory.apps.ofaapp.OpenFactoryApp>` deployed on the OpenFactory cluster, the environment variables ``KAFKA_BROKER`` and ``ASSET_ROUTER_URL`` will be set.
         """
-        super().__setattr__("_test_mode", test_mode)
+        super().__setattr__('ofa_attributes', {})
+        super().__setattr__('ofa_methods', {})
+        self._condition: threading.Condition = threading.Condition()
+        self._attribute_callbacks: dict[str, AssetNATSCallback] = {}
+        self._messages_callback: AssetNATSCallback | None = None
+        self._samples_callback: AssetNATSCallback | None = None
+        self._events_callback: AssetNATSCallback | None = None
+        self._conditions_callback: AssetNATSCallback | None = None
+        self._test_mode = test_mode
 
         # If in test mode, skip all runtime checks and producer setup
         if test_mode:
-            super().__setattr__("_mocked_attributes", [])
-            super().__setattr__("ksql", ksqlClient)
-            super().__setattr__("loop_thread", None)
-            super().__setattr__("subscribers", {})
-            super().__setattr__("bootstrap_servers", bootstrap_servers)
-            super().__setattr__("asset_router_url", asset_router_url)
-            super().__setattr__("producer", None)
+            self.ksql = ksqlClient
+            self.loop_thread = None
+            self.bootstrap_servers = bootstrap_servers
+            self.asset_router_url = asset_router_url
+            self.producer = None
             return
 
         if not hasattr(self, 'KSQL_ASSET_TABLE') or self.KSQL_ASSET_TABLE is None:
@@ -118,9 +131,8 @@ class BaseAsset:
         if not issubclass(self.ASSET_CONSUMER_CLASS, (KafkaAssetConsumer, KafkaAssetUNSConsumer)):
             raise TypeError("ASSET_CONSUMER_CLASS must be a subclass of KafkaAssetConsumer or KafkaAssetUNSConsumer.")
 
-        super().__setattr__('ksql', ksqlClient)
-        super().__setattr__('loop_thread', AsyncLoopThread())
-        super().__setattr__('subscribers', {})
+        self.ksql = ksqlClient
+        self.loop_thread = AsyncLoopThread()
 
         if bootstrap_servers is None:
             bootstrap_servers = os.getenv("KAFKA_BROKER")
@@ -129,7 +141,7 @@ class BaseAsset:
                 "OpenFactory BaseAsset requires 'bootstrap_servers' to be provided "
                 "either explicitly or via the KAFKA_BROKER environment variable."
             )
-        super().__setattr__('bootstrap_servers', bootstrap_servers)
+        self.bootstrap_servers = bootstrap_servers
 
         if asset_router_url is None:
             asset_router_url = os.getenv("ASSET_ROUTER_URL")
@@ -138,7 +150,7 @@ class BaseAsset:
                 "OpenFactory BaseAsset requires 'asset_router_url' to be provided "
                 "either explicitly or via the ASSET_ROUTER_URL environment variable."
             )
-        super().__setattr__('asset_router_url', asset_router_url)
+        self.asset_router_url = asset_router_url
 
         # Initialize the shared producer once
         if BaseAsset._shared_producer is None:
@@ -148,27 +160,35 @@ class BaseAsset:
             )
 
         # Use shared producer
-        super().__setattr__('producer', BaseAsset._shared_producer)
+        self.producer = BaseAsset._shared_producer
+
+        # Retrieve current state from ksqlDB
+        self._fetch_attributes()
+        self._fetch_methods()
+
+        # Start NATS subscription to update internal state
+        self.__start_nats_consumer()
 
     def close(self):
         """
-        Gracefully closes the Asset and frees ressources.
+        Closes the permanent NATS subscription and releases all resources owned by this BaseAsset.
 
         Steps performed:
-            1. Stops all NATS subscribers (unsubscribe + close NATS connection).
+            1. Stops the asset's NATS subscriber (unsubscribe + close NATS connection).
             2. Cancels any remaining tasks in the AsyncLoopThread.
             3. Stops the AsyncLoopThread and joins the thread.
 
         .. warning::
             After calling this method, the Asset instance should not be used again.
         """
-        # Stop all NATS subscribers
-        for key, sub in list(self.subscribers.items()):
-            try:
-                sub.stop()
-            except Exception as e:
-                print(f"Warning: failed to close NATS subscriber {key}: {e}")
-        self.subscribers.clear()
+        if self._test_mode:
+            return
+
+        # Stop NATS subscriber
+        try:
+            self._subscriber.stop()
+        except Exception as e:
+            print(f"Warning: failed to close NATS subscriber: {e}")
 
         # Cancel any remaining pending tasks in the loop
         loop = self.loop_thread.loop
@@ -185,21 +205,112 @@ class BaseAsset:
         if self.loop_thread:
             self.loop_thread.stop()
 
-    def _get_mocked_attribute_by_id(self, target_id: str) -> AssetAttribute | None:
+    def _parse_method_value(self, value: Any) -> Any:
         """
-        Retrieve a mocked AssetAttribute by its ID.
+        Parses the VALUE field of a Method attribute.
 
-        Args:
-            target_id (str): The ID of the AssetAttribute to retrieve.
-
-        Returns:
-            AssetAttribute | None: The matching AssetAttribute if found,
-            otherwise None.
+        Method contracts are stored as JSON strings in ksqlDB and converted
+        to their Python dictionary representation.
         """
-        return next(
-            (attr for attr in self._mocked_attributes if attr.id == target_id),
-            None
-        )
+
+        if value is None:
+            return None
+
+        if isinstance(value, dict):
+            return value
+
+        if isinstance(value, str):
+            try:
+                return json.loads(value)
+            except json.JSONDecodeError:
+                return value
+
+        return value
+
+    def _on_message(self, subject: str, msg: dict[str, Any]) -> None:
+        """
+        Processes an incoming NATS message.
+
+        Updates the internal asset state, notifies waiting threads, and
+        dispatches all registered callbacks.
+        """
+        msg = CaseInsensitiveDict(msg)
+        attribute_id = subject.split(".", 1)[1]
+
+        if msg['TYPE'] in {'Samples', 'Condition', 'Events', 'OpenFactory'}:
+            attr = AssetAttribute(
+                id=attribute_id,
+                value=msg['VALUE'],
+                type=msg['TYPE'],
+                tag=msg['TAG'],
+                timestamp=msg['attributes']['timestamp']
+            )
+            with self._condition:
+                self.ofa_attributes[attribute_id] = attr
+                self._condition.notify_all()
+
+            # Attribute callback
+            callback = self._attribute_callbacks.get(attribute_id)
+            if callback is not None:
+                callback(subject, msg)
+
+            # Global callback
+            if self._messages_callback is not None:
+                self._messages_callback(subject, msg)
+
+            # Samples callback
+            if (self._samples_callback is not None and msg["TYPE"] == "Samples"):
+                self._samples_callback(subject, msg)
+
+            # Events callback
+            if (self._events_callback is not None and msg["TYPE"] == "Events"):
+                self._events_callback(subject, msg)
+
+            # Conditions callback
+            if (self._conditions_callback is not None and msg["TYPE"] == "Condition"):
+                self._conditions_callback(subject, msg)
+
+        if msg["TYPE"] == "Method":
+            self.ofa_methods[attribute_id] = self._parse_method_value(msg["VALUE"])
+
+    def _fetch_attributes(self):
+        """ Retrieves all non-method attributes from ksqlDB and initializes the internal ``ofa_attributes`` dictionary. """
+        # test_mode
+        if getattr(self, "_test_mode", False):
+            return
+
+        # in production query ksqlDB
+        query = f"SELECT ID, VALUE, TYPE, TAG, TIMESTAMP FROM {self.KSQL_ASSET_TABLE} WHERE {self.KSQL_ASSET_ID}='{self.ASSET_ID}' AND TYPE != 'Method';"
+        result = self.ksql.query(query)
+        for row in result:
+            attr_value = row["VALUE"]
+            if row["TYPE"] == "Samples" and attr_value is not None:
+                try:
+                    attr_value = float(attr_value)
+                except (TypeError, ValueError):
+                    pass
+
+            attr = AssetAttribute(
+                id=row['ID'],
+                value=attr_value,
+                type=row['TYPE'],
+                tag=row['TAG'],
+                timestamp=row['TIMESTAMP']
+            )
+            self.ofa_attributes[row['ID']] = attr
+
+    def _fetch_methods(self):
+        """ Retrieves the current methods of the asset from ksqlDB and initializes the internal ``ofa_methods`` dictionary. """
+        # test_mode
+        if getattr(self, "_test_mode", False):
+            return
+
+        # in production query ksqlDB
+        query = f"SELECT ID, VALUE, TYPE FROM {self.KSQL_ASSET_TABLE} WHERE {self.KSQL_ASSET_ID}='{self.ASSET_ID}' AND TYPE='Method';"
+        result = self.ksql.query(query)
+
+        for row in result:
+            self.ofa_methods[row["ID"]] = self._parse_method_value(row["VALUE"])
 
     @property
     def asset_uuid(self) -> str:
@@ -240,23 +351,16 @@ class BaseAsset:
 
     def attributes(self) -> List[str]:
         """
-        Returns all non-``Method`` attribute IDs associated with this asset.
+        Returns the IDs of all attributes currently associated with this asset.
 
         Returns:
             List[str]: A list of attribute IDs.
         """
-        # return internal mock list in test_mode
-        if getattr(self, "_test_mode", False):
-            return [attr.id for attr in self._mocked_attributes]
-
-        # in production query ksqlDB
-        query = f"SELECT ID FROM {self.KSQL_ASSET_TABLE} WHERE {self.KSQL_ASSET_ID}='{self.ASSET_ID}' AND TYPE != 'Method';"
-        result = self.ksql.query(query)
-        return [row['ID'] for row in result]
+        return [attr.id for attr in self.ofa_attributes.values()]
 
     def _get_attributes_by_type(self, attr_type: str) -> List[Dict[str, Any]]:
         """
-        Generic method to retrieve all attributes from the `KSQL_ASSET_TABLE` of a given TYPE.
+        Returns all asset attributes of the specified type.
 
         Args:
             attr_type (str): The type of the asset attribute ('Samples', 'Events', 'Condition').
@@ -264,26 +368,13 @@ class BaseAsset:
         Returns:
             List[Dict]: A list of dictionaries containing 'ID', 'VALUE', and cleaned 'TAG'.
         """
-        if getattr(self, "_test_mode", False):
-            return [
-                {
-                    "ID": attr.id,
-                    "VALUE": attr.value,
-                    "TAG": attr.tag,
-                }
-                for attr in self._mocked_attributes
-                if attr.type == attr_type
-            ]
-
-        query = f"SELECT ID, VALUE, TAG, TYPE FROM {self.KSQL_ASSET_TABLE} WHERE {self.KSQL_ASSET_ID}='{self.ASSET_ID}' AND TYPE='{attr_type}';"
-        result = self.ksql.query(query)
         return [
             {
-                "ID": row["ID"],
-                "VALUE": row["VALUE"],
-                "TAG": re.sub(r'\{.*?\}', '', row["TAG"]).strip()
+                "ID": attr.id,
+                "VALUE": attr.value,
+                "TAG": re.sub(r'\{.*?\}', '', attr.tag).strip()
             }
-            for row in result
+            for attr in self.ofa_attributes.values() if attr.type == attr_type
         ]
 
     def samples(self) -> List[Dict[str, Any]]:
@@ -324,7 +415,7 @@ class BaseAsset:
 
     def methods(self) -> Dict[str, dict | None]:
         """
-        Returns method-type attributes for this asset.
+        Returns all methods associated with the asset.
 
         Returns:
             Dict[str, dict | None]:
@@ -355,36 +446,9 @@ class BaseAsset:
                 }
              }
         """
-        query = f"SELECT ID, VALUE, TYPE FROM {self.KSQL_ASSET_TABLE} WHERE {self.KSQL_ASSET_ID}='{self.ASSET_ID}' AND TYPE='Method';"
-        result = self.ksql.query(query)
-        parsed: Dict[str, Any] = {}
+        return self.ofa_methods
 
-        for row in result:
-            value = row.get("VALUE")
-
-            if value is None:
-                parsed[row["ID"]] = None
-                continue
-
-            # If already parsed (rare but possible depending on driver)
-            if isinstance(value, dict):
-                parsed[row["ID"]] = value
-                continue
-
-            # If JSON string → parse
-            if isinstance(value, str):
-                try:
-                    parsed[row["ID"]] = json.loads(value)
-                except json.JSONDecodeError:
-                    parsed[row["ID"]] = value
-                continue
-
-            # Fallback
-            parsed[row["ID"]] = value
-
-        return parsed
-
-    def method(self, method: str, sender_uuid: str, args: Optional[List[Tuple[str, str]]] = None) -> str:
+    def method(self, method: str, sender_uuid: str, args: list[tuple[str, str]] | None) -> str:
         """
         Requests the execution of a method for the asset.
 
@@ -413,7 +477,7 @@ class BaseAsset:
         Args:
             method (str): Name of the method to be executed.
             sender_uuid (str): Asset UUID of the asset sending the request.
-            args (Optional[List[Tuple[str, str]]]): List of (argument_name, value) pairs.
+            args (list[tuple[str, str]] | None): List of (argument_name, value) pairs.
 
                 All values must be strings. Defaults to empty list if not provided.
 
@@ -437,12 +501,11 @@ class BaseAsset:
 
         return str(correlation_id)
 
-    def __getattr__(self, attribute_id: str) -> AssetAttribute | Callable[..., Any]:
+    def __getattr__(self, attribute_id: str) -> AssetAttribute | Callable[..., str]:
         """
         Allows access to samples, events, conditions, and methods as attributes.
 
-        Dynamically retrieves asset attributes (e.g. events, conditions, or methods)
-        based on the `attribute_id` and returns them as an `AssetAttribute`.
+        Returns an attribute or method from the internal asset state.
         If the attribute is a method, it returns a callable function to execute that method.
 
         Args:
@@ -453,26 +516,9 @@ class BaseAsset:
                 - If the attribute is a sample, event, or condition, returns an AssetAttribute.
                 - If the attribute is a method, returns a callable method caller function.
         """
-        if getattr(self, "_test_mode", False):
-            return self._get_mocked_attribute_by_id(attribute_id)
+        if attribute_id in self.ofa_methods:
 
-        query = f"SELECT VALUE, TYPE, TAG, TIMESTAMP FROM {self.KSQL_ASSET_TABLE} WHERE key='{self.ASSET_ID}|{attribute_id}';"
-        result = self.ksql.query(query)
-
-        if not result:
-            return AssetAttribute(
-                id=attribute_id,
-                value='UNAVAILABLE',
-                type='UNAVAILABLE',
-                tag='UNAVAILABLE',
-                timestamp='UNAVAILABLE'
-            )
-
-        first_row = result[0]
-
-        if first_row['TYPE'] == 'Method':
-
-            def method_caller(**kwargs) -> str:
+            def method_caller(**kwargs: Any) -> str:
                 """
                 Executes the asset method with named string arguments.
 
@@ -492,21 +538,27 @@ class BaseAsset:
 
             return method_caller
 
-        return AssetAttribute(
-            id=attribute_id,
-            value=float(first_row['VALUE']) if first_row['TYPE'] == 'Samples' and first_row['VALUE'] != 'UNAVAILABLE' else first_row['VALUE'],
-            type=first_row['TYPE'],
-            tag=first_row['TAG'],
-            timestamp=first_row['TIMESTAMP']
-        )
+        if attribute_id not in self.ofa_attributes:
+            return AssetAttribute(
+                id=attribute_id,
+                value='UNAVAILABLE',
+                type='UNAVAILABLE',
+                tag='UNAVAILABLE',
+                timestamp='UNAVAILABLE'
+            )
+
+        return self.ofa_attributes[attribute_id]
 
     def __setattr__(self, name: str, value: Any) -> None:
         """
-        Sets attributes on the Asset object and sends updates to Kafka.
+        Updates the local asset state and publishes attribute changes to Kafka.
 
-        Overrides the default attribute setting behavior. If the attribute name
-        exists in the asset's defined attributes (`self.attributes()`), it updates the attribute's
-        value and sends the update to Kafka using the asset's producer.
+        Asset attributes are immediately reflected in the local asset state before being
+        published to the OpenFactory event stream.
+
+        Overrides the default attribute setting behavior. If the attribute name corresponds
+        to an existing asset attribute, its value is updated and published to the OpenFactory
+        event stream.
 
         If the attribute is **not** a defined Asset attribute:
         - It is treated as a regular class attribute and set normally.
@@ -532,8 +584,11 @@ class BaseAsset:
         Raises:
             OFAException: If the attribute is not defined in the asset but the value is an `AssetAttribute`.
         """
+        if name in self.ofa_methods:
+            raise OFAException(f"{name} is an Asset method. It can not be assigned.")
+
         # if not an Asset attributes, handle it as a class attribute
-        if name not in self.attributes():
+        if name not in self.ofa_attributes:
             if isinstance(value, AssetAttribute):
                 raise OFAException(f"The attribute {name} is not defined in the asset {self.ASSET_ID}. Use the `add_attribute` method to define a new asset attribute.")
             super().__setattr__(name, value)
@@ -543,39 +598,42 @@ class BaseAsset:
         if isinstance(value, AssetAttribute):
             if value.id != name:
                 raise OFAException(f"The AssetAttribute.id {value.id} does not match the attribute {name}")
-            self.producer.send_asset_attribute(self.asset_uuid, value)
+            self.ofa_attributes[name] = value
+            if not self._test_mode:
+                self.producer.send_asset_attribute(self.asset_uuid, value)
             return
 
         # get the current AssetAttribute
-        attr = self.__getattr__(name)
+        attr = self.ofa_attributes[name]
 
-        if getattr(self, "_test_mode", False):
-            # update its value
-            attr.value = value
-            return
+        new_attr = AssetAttribute(
+            id=name,
+            value=value,
+            tag=attr.tag,
+            type=attr.type
+        )
+        self.ofa_attributes[name] = new_attr
 
         # send kafka message
-        self.producer.send_asset_attribute(
-            self.asset_uuid,
-            AssetAttribute(
-                id=name,
-                value=value,
-                tag=attr.tag,
-                type=attr.type)
-            )
+        if not self._test_mode:
+            self.producer.send_asset_attribute(self.asset_uuid, new_attr)
 
     def add_attribute(self, asset_attribute: AssetAttribute, wait_to_become_available: bool = True) -> None:
         """
-        Adds a new attribute to the asset.
+        Adds a new attribute to the local asset state and publishes it to the OpenFactory event stream.
+
+        The attribute is immediately added to the local asset state before being published
+        to the OpenFactory event stream.
 
         Args:
             asset_attribute (AssetAttribute): The attribute to be added.
-            wait_to_become_available (bool): If true, will wait until the Attribute is available in ksqlDB
+            wait_to_become_available (bool): If True, waits until the newly added attribute has been materialized in ksqlDB before returning.
         """
-        if getattr(self, "_test_mode", False):
-            # add to internal mock list
-            self._mocked_attributes.append(asset_attribute)
+        self.ofa_attributes[asset_attribute.id] = asset_attribute
+
+        if self._test_mode:
             return
+
         self.producer.send_asset_attribute(self.asset_uuid, asset_attribute)
         if wait_to_become_available:
             self.wait_until(attribute_id=asset_attribute.id, value=asset_attribute.value, use_ksqlDB=True)
@@ -681,184 +739,237 @@ class BaseAsset:
         """
         self._add_reference(direction="below", new_reference=below_asset_reference)
 
-    def wait_until(self, attribute_id: str, value: Any, timeout: int = 30, use_ksqlDB: bool = False) -> bool:
+    def wait_until(self, attribute_id: str, value: Any, comparison: Callable[[Any, Any], bool] = eq, timeout: int = 30, use_ksqlDB: bool = False) -> bool:
         """
-        Waits until the asset attribute has a specific value or times out.
+        Waits until an asset attribute satisfies a comparison or times out.
 
-        Monitors either the NATS cluster or ksqlDB to check if the attribute value matches the expected value.
-        Returns True if the value is found within the given timeout, False otherwise.
+        Waits until the specified asset attribute satisfies the given comparison
+        against ``value``. By default, the comparison is performed against the
+        asset's locally cached state, which is continuously updated from the
+        OpenFactory event stream. If ``use_ksqlDB=True``, the comparison is instead
+        performed against the distributed state materialized in ksqlDB, ensuring
+        that the complete stream-processing pipeline has propagated the update.
+
+        .. admonition:: Example usage:
+
+            .. code-block:: python
+
+                from operator import gt, ge, lt, le
+
+                asset.wait_until("Execution", "ACTIVE")
+                asset.wait_until("Temperature", 42)
+                asset.wait_until("Temperature", 42, gt)
+                asset.wait_until("Temperature", 42, ge)
+                asset.wait_until("Temperature", 100, lt)
+                asset.wait_until("Temperature", 100, le)
 
         Args:
             attribute_id (str): The attribute ID of the asset to monitor.
-            value (Any): The value to wait for the attribute to match.
+            value (Any): The reference value used for the comparison.
+            comparison (Callable[[Any, Any], bool]):
+                Function used to compare the current attribute value with
+                ``value``. Defaults to :func:`operator.eq`.
             timeout (int): The maximum time to wait, in seconds. Default is 30 seconds.
-            use_ksqlDB (bool): If `True`, uses ksqlDB instead of NATS to check the attribute value. Default is `False`.
+            use_ksqlDB (bool):
+                If ``False`` (default), waits for the local cached state to satisfy
+                the comparison. If ``True``, waits until the distributed state
+                materialized in ksqlDB satisfies the comparison.
 
         Returns:
-            bool: `True` if the attribute value matches the expected value within the timeout, `False` otherwise.
+            bool: `True` if the comparison is satisfied before the timeout expires, otherwise ``False``.
         """
-        # First, check the current attribute value
-        attribute = self.__getattr__(attribute_id)
-        if type(attribute) is AssetAttribute:
-            if attribute.value == value and attribute.timestamp != 'UNAVAILABLE':
-                return True
+        # If not an attribute  raise
+        if attribute_id not in self.ofa_attributes:
+            raise OFAException(f"'{attribute_id}' is not an Attribute of Asset '{self.asset_uuid}'")
 
-        # If an OpenFactory method, wait_until is not applicable
-        if callable(attribute):
+        # First, check the current attribute value
+        if comparison(self.ofa_attributes[attribute_id].value, value):
             return True
 
-        start_time = time.time()
-
+        # Checks that the full stream-processing pipeline has completed
         if use_ksqlDB:
+            start_time = time.time()
+
             while True:
-                # Check for timeout
                 if (time.time() - start_time) > timeout:
                     return False
-                attribute = self.__getattr__(attribute_id)
-                if type(attribute) is AssetAttribute:
-                    if attribute.value == value and attribute.timestamp != 'UNAVAILABLE':
+
+                query = (f"SELECT VALUE, TYPE, TIMESTAMP FROM {self.KSQL_ASSET_TABLE} WHERE key='{self.ASSET_ID}|{attribute_id}';")
+                result = self.ksql.query(query)
+
+                if result:
+                    row = result[0]
+                    current = row["VALUE"]
+                    if row["TYPE"] == "Samples":
+                        try:
+                            current = float(current)
+                        except (TypeError, ValueError):
+                            pass
+                    if comparison(current, value):
                         return True
+
                 time.sleep(0.1)
 
-        event = threading.Event()
-        result = {"found": False}
+        with self._condition:
+            return self._condition.wait_for(
+                lambda: comparison(
+                    self.ofa_attributes[attribute_id].value,
+                    value
+                ),
+                timeout=timeout,
+            )
 
-        def on_message(subject: str, msg_value: dict):
-            msg_value = CaseInsensitiveDict(msg_value)
-            if msg_value.get("type") == "Samples" and msg_value.get("value") != "UNAVAILABLE":
-                try:
-                    if float(msg_value["value"]) == value:
-                        result["found"] = True
-                        event.set()
-                except ValueError:
-                    pass
-            else:
-                if msg_value.get("value") == value:
-                    result["found"] = True
-                    event.set()
-
-        sub_key = f"wait_{attribute_id}_{uuid.uuid4()}"
-        self.__start_nats_consumer(f"{self.asset_uuid.upper()}.{attribute_id}", on_message, sub_key=sub_key)
-
-        finished = event.wait(timeout=timeout)
-
-        self.__stop_subscription(sub_key)
-
-        return finished and result["found"]
-
-    def __start_nats_consumer(self, subject: str, on_message, sub_key: str):
-        """
-        Starts a NATS subscriber and stores it in self.subscribers with a unique key.
-        """
-        sub = NATSSubscriber(
+    def __start_nats_consumer(self):
+        """ Starts the asset's NATS subscriber. """
+        asset_uuid = self.asset_uuid
+        self._subscriber = NATSSubscriber(
             self.loop_thread,
-            get_nats_cluster_url(self.asset_uuid, self.asset_router_url),
-            subject, on_message)
-        sub.start()
-        self.subscribers[sub_key] = sub
+            get_nats_cluster_url(asset_uuid, self.asset_router_url),
+            f"{asset_uuid.upper()}.*",
+            self._on_message,
+        )
+        self._subscriber.start()
 
-    def __stop_subscription(self, subject: str) -> None:
+    def _restart_nats_subscription(self):
         """
-        Stops a NATS subscription and cleans up associated resources.
+        Restarts the asset's NATS subscriber.
 
-        Args:
-            subject (str): Subject of NATS subsription to stop
+        This method is used when the asset UUID changes after construction
+        (for example, during initialization of derived classes).
+        The subscriber is recreated using the new subject so that the internal state
+        continues to receive updates for the correct asset.
         """
-        sub = self.subscribers.pop(subject, None)
-        if sub:
-            sub.stop()
+
+        # Nothing to do in test mode
+        if self._test_mode:
+            return
+
+        # Stop current subscriber
+        try:
+            self._subscriber.stop()
+        except Exception as e:
+            print(f"Warning: failed to close NATS subscriber: {e}")
+
+        # Cancel any remaining pending tasks in the loop
+        loop = self.loop_thread.loop
+        pending = asyncio.all_tasks(loop=loop)
+        for task in pending:
+            task.cancel()
+
+        if pending:
+            try:
+                loop.run_until_complete(
+                    asyncio.gather(*pending, return_exceptions=True)
+                )
+            except Exception:
+                pass
+
+        # Recreate subscriber with the current asset UUID
+        asset_uuid = self.asset_uuid
+        self._subscriber = NATSSubscriber(
+            self.loop_thread,
+            get_nats_cluster_url(asset_uuid, self.asset_router_url),
+            f"{asset_uuid.upper()}.*",
+            self._on_message,
+        )
+        self._subscriber.start()
 
     def subscribe_to_attribute(self, attribute_id: str, on_message: AssetNATSCallback) -> None:
         """
-        Subscribes to changes of an asset attribute using a NATS consumer.
+        Registers a callback invoked whenever the specified asset attribute changes.
 
         Args:
             attribute_id (str): The attribute ID to monitor.
             on_message (AssetNATSCallback): Callable that takes (msg_subject: str, msg_value: dict) and handles messages.
         """
-        subject = f"{self.asset_uuid.upper()}.{attribute_id}"
-        sub_key = f"subscribe_to_attribute_{attribute_id}"
-        self.__start_nats_consumer(subject, on_message, sub_key=sub_key)
+        if attribute_id in self._attribute_callbacks:
+            raise OFAException(
+                f"A callback is already registered for attribute '{attribute_id}'. "
+                f"Call stop_attribute_subscription('{attribute_id}') before registering a new callback."
+            )
+        self._attribute_callbacks[attribute_id] = on_message
 
     def subscribe_to_messages(self, on_message: AssetNATSCallback) -> None:
         """
-        Subscribes to asset messages using a NATS consumer.
+        Registers a callback invoked for every incoming asset message.
 
         Args:
             on_message (AssetNATSCallback): Callable that takes (msg_subject: str, msg_value: dict) and handles messages.
         """
-        subject = f"{self.asset_uuid.upper()}.*"
-        self.__start_nats_consumer(subject, on_message, sub_key="messages")
+        if self._messages_callback is not None:
+            raise OFAException(
+                "A callback is already registered for asset messages. "
+                "Call stop_messages_subscription() before registering a new callback."
+            )
+
+        self._messages_callback = on_message
 
     def stop_attribute_subscription(self, attribute_id: str) -> None:
         """
-        Stops the NATS consumer and gracefully shuts down the subscription.
+        Unregisters the callback associated with the specified attribute.
 
         Args:
             attribute_id (str): The attribute ID to for which to stop the subscription.
         """
-        self.__stop_subscription(f"subscribe_to_attribute_{attribute_id}")
+        self._attribute_callbacks.pop(attribute_id, None)
 
     def stop_messages_subscription(self) -> None:
-        """ Stops the NATS consumer and gracefully shuts down the subscription. """
-        self.__stop_subscription("messages")
+        """ Unregisters the callback for asset messages. """
+        self._messages_callback = None
 
     def subscribe_to_samples(self, on_sample: AssetNATSCallback) -> None:
         """
-        Subscribes to asset samples using a NATS consumer.
+        Registers a callback invoked for incoming sample messages.
 
         Args:
             on_sample (AssetNATSCallback): Callable that takes (msg_subject: str, msg_value: dict).
         """
-        subject = f"{self.asset_uuid.upper()}.*"
+        if self._samples_callback is not None:
+            raise OFAException(
+                "A callback is already registered for asset samples. "
+                "Call stop_samples_subscription() before registering a new callback."
+            )
 
-        def _filter_samples(msg_subject: str, msg_value: dict):
-            msg_value = CaseInsensitiveDict(msg_value)
-            if msg_value.get("TYPE").upper() == "SAMPLES":
-                on_sample(msg_subject, msg_value)
-
-        self.__start_nats_consumer(subject, _filter_samples, sub_key="samples")
+        self._samples_callback = on_sample
 
     def stop_samples_subscription(self) -> None:
-        """ Stops the NATS consumer and gracefully shuts down the subscription for samples. """
-        self.__stop_subscription("samples")
+        """ Unregisters the callback for sample messages. """
+        self._samples_callback = None
 
     def subscribe_to_events(self, on_event: AssetNATSCallback) -> None:
         """
-        Subscribes to asset events using a NATS consumer.
+        Registers a callback invoked for incoming event messages.
 
         Args:
             on_event (AssetNATSCallback): Callable that takes (msg_subject: str, msg_value: dict).
         """
-        subject = f"{self.asset_uuid.upper()}.*"
+        if self._events_callback is not None:
+            raise OFAException(
+                "A callback is already registered for asset events. "
+                "Call stop_events_subscription() before registering a new callback."
+            )
 
-        def _filter_events(msg_subject: str, msg_value: dict):
-            msg_value = CaseInsensitiveDict(msg_value)
-            if msg_value.get("TYPE").upper() == "EVENTS":
-                on_event(msg_subject, msg_value)
-
-        self.__start_nats_consumer(subject, _filter_events, sub_key="events")
+        self._events_callback = on_event
 
     def stop_events_subscription(self) -> None:
-        """ Stops the NATS consumer and gracefully shuts down the subscription for events. """
-        self.__stop_subscription("events")
+        """ Unregisters the callback for event messages. """
+        self._events_callback = None
 
     def subscribe_to_conditions(self, on_condition: AssetNATSCallback) -> None:
         """
-        Subscribes to asset conditions using a NATS consumer.
+        Registers a callback invoked for incoming condition messages.
 
         Args:
             on_condition (AssetNATSCallback): Callable that takes (msg_subject: str, msg_value: dict).
         """
-        subject = f"{self.asset_uuid.upper()}.*"
+        if self._conditions_callback is not None:
+            raise OFAException(
+                "A callback is already registered for asset conditions. "
+                "Call stop_conditions_subscription() before registering a new callback."
+            )
 
-        def _filter_conditions(msg_subject: str, msg_value: dict):
-            msg_value = CaseInsensitiveDict(msg_value)
-            if msg_value.get("TYPE").upper() == "CONDITION":
-                on_condition(msg_subject, msg_value)
-
-        self.__start_nats_consumer(subject, _filter_conditions, sub_key="conditions")
+        self._conditions_callback = on_condition
 
     def stop_conditions_subscription(self) -> None:
-        """ Stops the NATS consumer and gracefully shuts down the subscription for conditions. """
-        self.__stop_subscription("conditions")
+        """ Unregisters the callback for condition messages. """
+        self._conditions_callback = None

--- a/openfactory/assets/asset_class.py
+++ b/openfactory/assets/asset_class.py
@@ -9,10 +9,14 @@ from openfactory.kafka import KafkaAssetConsumer, KSQLDBClient
 
 class Asset(BaseAsset):
     """
-    Represents an OpenFactory Asset using the ``ASSET_UUID`` as identifier.
+    Represents an OpenFactory asset using the ``ASSET_UUID`` as identifier.
 
-    This class encapsulates Asset metadata and a Kafka producer responsible for sending asset data.
-    It uses the ksqlDB topology based on the ``ASSETS_STREAM`` stream to handle Asset data.
+    This class represents an OpenFactory asset. It maintains a locally cached view of the
+    asset state synchronized with the OpenFactory platform while providing methods
+    to publish attribute updates and invoke asset methods.
+
+    It uses the OpenFactory data model to retrieve the initial asset state from ksqlDB
+    while keeping the local cache synchronized through the OpenFactory event stream.
 
     Attributes:
         asset_uuid (str): Unique identifier of the Asset.
@@ -55,23 +59,24 @@ class Asset(BaseAsset):
             def on_condition(msg_key, msg_value):
                 print(f"[Condition] [{msg_key}] {msg_value}")
 
-            cnc.subscribe_to_messages(on_messages, 'demo_messages_group')
-            cnc.subscribe_to_samples(on_sample, 'demo_samples_group')
-            cnc.subscribe_to_events(on_event, 'demo_events_group')
-            cnc.subscribe_to_conditions(on_condition, 'demo_conditions_group')
+            cnc.subscribe_to_messages(on_messages)
+            cnc.subscribe_to_samples(on_sample)
+            cnc.subscribe_to_events(on_event)
+            cnc.subscribe_to_conditions(on_condition)
 
             # run a main loop while subscriptions remain active
             try:
                 while True:
                     time.sleep(1)
             except KeyboardInterrupt:
-                print("Stopping consumer threads ...")
+                print("Stopping subscriptions ...")
                 cnc.stop_messages_subscription()
                 cnc.stop_samples_subscription()
                 cnc.stop_events_subscription()
                 cnc.stop_conditions_subscription()
-                print("Consumers stopped")
+                print("Subscriptions stopped")
             finally:
+                cnc.close()
                 ksql.close()
     """
 
@@ -85,7 +90,7 @@ class Asset(BaseAsset):
                  asset_router_url: str | None = None,
                  test_mode: bool = False) -> None:
         """
-        Initializes the Asset with metadata and a Kafka producer.
+        Initializes the Asset, its local state cache, and the communication infrastructure.
 
         Args:
             asset_uuid (str): UUID identifier of the asset.
@@ -126,14 +131,14 @@ class Asset(BaseAsset):
 
     def _get_reference_list(self, direction: str, as_assets: bool = False) -> list[str | Asset]:
         """
-        Retrieves a list of asset references (UUIDs or AssetUNS objects) in the given direction.
+        Retrieves a list of asset references (UUIDs or Asset objects) in the given direction.
 
         Args:
             direction (str): Either 'above' or 'below', indicating reference direction.
-            as_assets (bool): If True, returns AssetUNS instances instead of UUID strings.
+            as_assets (bool): If True, returns Asset instances instead of UUID strings.
 
         Returns:
-            List: List of asset UUIDs or AssetUNS objects.
+            list[str | Asset]: Asset UUIDs or Asset objects.
         """
         key = f"{self.asset_uuid}|references_{direction}"
         query = f"SELECT VALUE FROM assets WHERE key='{key}';"
@@ -183,22 +188,22 @@ if __name__ == "__main__":
         """ Callback to process received conditions. """
         print(f"[Condition] [{msg_key}] {msg_value}")
 
-    cnc.subscribe_to_messages(on_messages, 'demo_messages_group')
-    cnc.subscribe_to_samples(on_sample, 'demo_samples_group')
-    cnc.subscribe_to_events(on_event, 'demo_events_group')
-    cnc.subscribe_to_conditions(on_condition, 'demo_conditions_group')
+    cnc.subscribe_to_messages(on_messages)
+    cnc.subscribe_to_samples(on_sample)
+    cnc.subscribe_to_events(on_event)
+    cnc.subscribe_to_conditions(on_condition)
 
     # run a main loop while subscriptions remain active
     try:
         while True:
             time.sleep(1)
     except KeyboardInterrupt:
-        print("Stopping consumer threads ...")
+        print("Stopping subscriptions ...")
         cnc.stop_messages_subscription()
         cnc.stop_samples_subscription()
         cnc.stop_events_subscription()
         cnc.stop_conditions_subscription()
-        print("Consumers stopped")
+        print("Subscriptions stopped")
     finally:
+        cnc.close()
         ksql.close()
-        print("Closed conection to ksqlDB server")

--- a/openfactory/assets/asset_uns_class.py
+++ b/openfactory/assets/asset_uns_class.py
@@ -1,17 +1,22 @@
 """ OpenFactory AssetUNS class. """
 
 from __future__ import annotations
-from typing import List
+import threading
 from openfactory.assets.asset_base import BaseAsset
 from openfactory.kafka import KafkaAssetUNSConsumer, KSQLDBClient
+from openfactory.exceptions import OFAException
 
 
 class AssetUNS(BaseAsset):
     """
     Represents an OpenFactory Asset using the UNS identifier.
 
-    This class encapsulates Asset metadata and a Kafka producer responsible for sending Asset data.
-    It uses the ksqlDB topology based on the ``ASSETS_STREAM_UNS`` stream to handle Asset data.
+    This class represents an OpenFactory Asset identified by its UNS identifier. It maintains
+    a locally cached view of the Asset state synchronized with the OpenFactory platform while
+    providing methods to publish attribute updates and invoke Asset methods.
+
+    It uses the OpenFactory data model to retrieve the initial Asset state from ksqlDB
+    while keeping the local cache synchronized through the OpenFactory event stream.
 
     Note:
         All write operations to the asset take place in the ``assets`` stream.
@@ -60,23 +65,24 @@ class AssetUNS(BaseAsset):
             def on_condition(msg_key, msg_value):
                 print(f"[Condition] [{msg_key}] {msg_value}")
 
-            cnc.subscribe_to_messages(on_messages, 'demo_messages_group')
-            cnc.subscribe_to_samples(on_sample, 'demo_samples_group')
-            cnc.subscribe_to_events(on_event, 'demo_events_group')
-            cnc.subscribe_to_conditions(on_condition, 'demo_conditions_group')
+            cnc.subscribe_to_messages(on_messages)
+            cnc.subscribe_to_samples(on_sample)
+            cnc.subscribe_to_events(on_event)
+            cnc.subscribe_to_conditions(on_condition)
 
             # run a main loop while subscriptions remain active
             try:
                 while True:
                     time.sleep(1)
             except KeyboardInterrupt:
-                print("Stopping consumer threads ...")
+                print("Stopping subscriptions ...")
                 cnc.stop_messages_subscription()
                 cnc.stop_samples_subscription()
                 cnc.stop_events_subscription()
                 cnc.stop_conditions_subscription()
-                print("Consumers stopped")
+                print("Subscriptions stopped")
             finally:
+                cnc.close()
                 ksql.close()
     """
 
@@ -84,20 +90,29 @@ class AssetUNS(BaseAsset):
     KSQL_ASSET_ID = 'uns_id'
     ASSET_CONSUMER_CLASS = KafkaAssetUNSConsumer
 
+    _MAPPING_WATCH_INTERVAL = 2.0
+
     def __init__(self, uns_id: str,
                  ksqlClient: KSQLDBClient,
                  bootstrap_servers: str | None = None,
                  asset_router_url: str | None = None,
-                 test_mode: bool = False) -> None:
+                 test_mode: bool = False,
+                 start_mapping_watcher: bool = True) -> None:
+
         """
-        Initializes the Asset with metadata and a Kafka producer.
+        Initializes the Asset, its local state cache, and the communication infrastructure.
+
+        Besides initializing the local asset cache, this constructor optionally starts a
+        background thread that monitors changes to the UNS mapping and automatically
+        recreates the NATS subscription whenever the mapped Asset UUID changes.
 
         Args:
             uns_id (str): UNS identifier of the asset.
             ksqlClient (KSQLDBClient): Client for interacting with ksqlDB.
-            bootstrap_servers (str): Kafka bootstrap server address.
+            bootstrap_servers (str | None): Kafka bootstrap server address.
             asset_router_url (str | None): Asset Router URL from the OpenFactory Fan-Out-Layer.
             test_mode (bool): If True, disables live Kafka/ksql interaction (useful for unit tests).
+            start_mapping_watcher (bool): If ``True`` (default), starts the background thread that monitors changes in the UNS-to-Asset mapping.
 
         Raises:
             OFAException: If ``bootstrap_servers`` is not provided and the
@@ -109,12 +124,34 @@ class AssetUNS(BaseAsset):
           - If ``bootstrap_servers`` is not explicitly provided, the constructor will attempt to read it from the ``KAFKA_BROKER`` environment variable.
           - If ``asset_router_url`` is not explicitly provided, the constructor will attempt to read it from the ``ASSET_ROUTER_URL`` environment variable.
           - When used in an :class:`OpenFactoryApp <openfactory.apps.ofaapp.OpenFactoryApp>` deployed on the OpenFactory cluster, the environment variables ``KAFKA_BROKER`` and ``ASSET_ROUTER_URL`` will be set.
+
+        .. tip::
+           The environment variables ``KSQLDB_URL``, ``KAFKA_BROKER`` and ``ASSET_ROUTER_URL`` will be set when deployed on the OpenFactory Cluster.
         """
         object.__setattr__(self, 'ASSET_ID', uns_id)
         super().__init__(ksqlClient=ksqlClient,
                          bootstrap_servers=bootstrap_servers,
                          asset_router_url=asset_router_url,
                          test_mode=test_mode)
+
+        self._subscribed_asset_uuid: str | None = None
+
+        if not test_mode:
+
+            # UUID currently subscribed by the NATS subscriber
+            self._subscribed_asset_uuid = self.asset_uuid
+
+            # Create stop event
+            self._stop_mapping_watcher = threading.Event()
+
+            self._mapping_watcher: threading.Thread | None = None
+
+            if start_mapping_watcher:
+                self._mapping_watcher = threading.Thread(
+                    target=self._watch_asset_mapping,
+                    daemon=True,
+                )
+                self._mapping_watcher.start()
 
     @property
     def asset_uuid(self) -> str:
@@ -127,10 +164,10 @@ class AssetUNS(BaseAsset):
         query = f"SELECT asset_uuid FROM asset_to_uns_map WHERE {self.KSQL_ASSET_ID}='{self.ASSET_ID}';"
         result = self.ksql.query(query)
         if not result:
-            return None
+            raise OFAException(f"No Asset UUID mapping found for UNS asset '{self.ASSET_ID}'.")
         return result[0]['ASSET_UUID']
 
-    def _get_reference_list(self, direction: str, as_assets: bool = False) -> List[str | AssetUNS]:
+    def _get_reference_list(self, direction: str, as_assets: bool = False) -> list[str | AssetUNS]:
         """
         Retrieves a list of asset references (UUIDs or AssetUNS objects) in the given direction.
 
@@ -152,3 +189,41 @@ class AssetUNS(BaseAsset):
         if as_assets:
             return [AssetUNS(uns_id, ksqlClient=self.ksql) for uns_id in uns_ids]
         return uns_ids
+
+    def _check_asset_mapping(self):
+        """
+        Checks whether the Asset UUID currently associated with this UNS identifier has changed.
+
+        If the mapping changed, the existing NATS subscription is recreated
+        so the asset continues receiving updates for the newly mapped Asset.
+        """
+        current_uuid = self.asset_uuid
+
+        if current_uuid != self._subscribed_asset_uuid:
+            self._restart_nats_subscription()
+            self._subscribed_asset_uuid = current_uuid
+
+    def _watch_asset_mapping(self):
+        """
+        Background worker executed by a dedicated thread.
+
+        Periodically checks whether the UNS identifier resolves to a different
+        Asset UUID and updates the NATS subscription if required.
+        """
+        while not self._stop_mapping_watcher.wait(self._MAPPING_WATCH_INTERVAL):
+            self._check_asset_mapping()
+
+    def close(self):
+        """
+        Stops the background mapping watcher and then delegates resource cleanup
+        to :meth:`BaseAsset.close`.
+
+        This ensures the monitoring thread exits before the NATS subscriber and
+        other shared resources are released.
+        """
+        self._stop_mapping_watcher.set()
+
+        if self._mapping_watcher is not None and self._mapping_watcher.is_alive():
+            self._mapping_watcher.join(timeout=5)
+
+        super().close()

--- a/tests/openfactory/apps/test_openfactory_flask_app.py
+++ b/tests/openfactory/apps/test_openfactory_flask_app.py
@@ -50,6 +50,19 @@ class TestOpenFactoryFlaskApp(unittest.TestCase):
         self.deregister_patcher.start()
         self.addCleanup(self.deregister_patcher.stop)
 
+        # Patch get_nats_cluster_url
+        self.get_nats_cluster_url_patcher = patch(
+            "openfactory.assets.asset_base.get_nats_cluster_url",
+            return_value="nats://mock"
+        )
+        self.mock_get_nats_cluster_url = self.get_nats_cluster_url_patcher.start()
+        self.addCleanup(self.get_nats_cluster_url_patcher.stop)
+
+        # Patch NATSSubscriber
+        self.nats_subscriber_patcher = patch("openfactory.assets.asset_base.NATSSubscriber")
+        self.mock_nats_subscriber = self.nats_subscriber_patcher.start()
+        self.addCleanup(self.nats_subscriber_patcher.stop)
+
     def test_initialization_creates_flask(self):
         """ Test initialization creates Flask app """
 
@@ -246,6 +259,19 @@ class TestOpenFactoryFlaskAppAsync(unittest.IsolatedAsyncioTestCase):
         self.deregister_patcher = patch("openfactory.apps.ofaapp.deregister_asset")
         self.deregister_patcher.start()
         self.addCleanup(self.deregister_patcher.stop)
+
+        # Patch get_nats_cluster_url
+        self.get_nats_cluster_url_patcher = patch(
+            "openfactory.assets.asset_base.get_nats_cluster_url",
+            return_value="nats://mock"
+        )
+        self.mock_get_nats_cluster_url = self.get_nats_cluster_url_patcher.start()
+        self.addCleanup(self.get_nats_cluster_url_patcher.stop)
+
+        # Patch NATSSubscriber
+        self.nats_subscriber_patcher = patch("openfactory.assets.asset_base.NATSSubscriber")
+        self.mock_nats_subscriber = self.nats_subscriber_patcher.start()
+        self.addCleanup(self.nats_subscriber_patcher.stop)
 
     async def test_run_openfactory_calls_async_main_loop(self):
         """ Should call async_main_loop when user overrides it """

--- a/tests/openfactory/apps/test_openfactory_flask_app_http.py
+++ b/tests/openfactory/apps/test_openfactory_flask_app_http.py
@@ -51,6 +51,19 @@ class TestOpenFactoryFlaskAppHTTP(unittest.TestCase):
         self.wait_until_patcher.start()
         self.addCleanup(self.wait_until_patcher.stop)
 
+        # Patch get_nats_cluster_url
+        self.get_nats_cluster_url_patcher = patch(
+            "openfactory.assets.asset_base.get_nats_cluster_url",
+            return_value="nats://mock"
+        )
+        self.mock_get_nats_cluster_url = self.get_nats_cluster_url_patcher.start()
+        self.addCleanup(self.get_nats_cluster_url_patcher.stop)
+
+        # Patch NATSSubscriber
+        self.nats_subscriber_patcher = patch("openfactory.assets.asset_base.NATSSubscriber")
+        self.mock_nats_subscriber = self.nats_subscriber_patcher.start()
+        self.addCleanup(self.nats_subscriber_patcher.stop)
+
         self.app = _HTTPTestApp(
             ksqlClient=self.ksql_mock,
             bootstrap_servers="mock",

--- a/tests/openfactory/apps/test_openfactoryapp.py
+++ b/tests/openfactory/apps/test_openfactoryapp.py
@@ -29,6 +29,19 @@ class TestOpenFactoryApp(unittest.TestCase):
         self.mock_wait_until = self.wait_until_patcher.start()
         self.addCleanup(self.wait_until_patcher.stop)
 
+        # Patch get_nats_cluster_url
+        self.get_nats_cluster_url_patcher = patch(
+            "openfactory.assets.asset_base.get_nats_cluster_url",
+            return_value="nats://mock"
+        )
+        self.mock_get_nats_cluster_url = self.get_nats_cluster_url_patcher.start()
+        self.addCleanup(self.get_nats_cluster_url_patcher.stop)
+
+        # Patch NATSSubscriber
+        self.nats_subscriber_patcher = patch("openfactory.assets.asset_base.NATSSubscriber")
+        self.mock_nats_subscriber = self.nats_subscriber_patcher.start()
+        self.addCleanup(self.nats_subscriber_patcher.stop)
+
         # Patch deregister_asset
         self.deregister_patcher = patch('openfactory.apps.ofaapp.deregister_asset')
         self.mock_deregister = self.deregister_patcher.start()

--- a/tests/openfactory/apps/test_openfactoryapp_declarative_attributes.py
+++ b/tests/openfactory/apps/test_openfactoryapp_declarative_attributes.py
@@ -47,6 +47,19 @@ class TestDeclarativeAttributes(unittest.TestCase):
         self.wait_until_patcher.start()
         self.addCleanup(self.wait_until_patcher.stop)
 
+        # Patch get_nats_cluster_url
+        self.get_nats_cluster_url_patcher = patch(
+            "openfactory.assets.asset_base.get_nats_cluster_url",
+            return_value="nats://mock"
+        )
+        self.mock_get_nats_cluster_url = self.get_nats_cluster_url_patcher.start()
+        self.addCleanup(self.get_nats_cluster_url_patcher.stop)
+
+        # Patch NATSSubscriber
+        self.nats_subscriber_patcher = patch("openfactory.assets.asset_base.NATSSubscriber")
+        self.mock_nats_subscriber = self.nats_subscriber_patcher.start()
+        self.addCleanup(self.nats_subscriber_patcher.stop)
+
         self.app = TestApp(ksqlClient=self.ksql_mock, bootstrap_servers="mocked_broker", asset_router_url="mocked_url")
 
     def test_declared_attributes_collection(self):

--- a/tests/openfactory/apps/test_openfactoryapp_methods.py
+++ b/tests/openfactory/apps/test_openfactoryapp_methods.py
@@ -45,6 +45,19 @@ class TestOpenFactoryAppMethods(unittest.TestCase):
         self.mock_producer_cls = self.asset_producer_patch.start()
         self.addCleanup(self.asset_producer_patch.stop)
 
+        # Patch get_nats_cluster_url
+        self.get_nats_cluster_url_patcher = patch(
+            "openfactory.assets.asset_base.get_nats_cluster_url",
+            return_value="nats://mock"
+        )
+        self.mock_get_nats_cluster_url = self.get_nats_cluster_url_patcher.start()
+        self.addCleanup(self.get_nats_cluster_url_patcher.stop)
+
+        # Patch NATSSubscriber
+        self.nats_subscriber_patcher = patch("openfactory.assets.asset_base.NATSSubscriber")
+        self.mock_nats_subscriber = self.nats_subscriber_patcher.start()
+        self.addCleanup(self.nats_subscriber_patcher.stop)
+
     def test_ofa_method_decorator_metadata(self):
         """ Verify that @ofa_method stores correct metadata """
         class MyApp(OpenFactoryApp):

--- a/tests/openfactory/apps/test_openfactoryapp_test_mode.py
+++ b/tests/openfactory/apps/test_openfactoryapp_test_mode.py
@@ -59,12 +59,12 @@ class TestOpenFactoryAppTestMode(TestCase):
         """ Test that add_attributes populates internal list in test_mode """
         # Add two AssetAttributes
         attribute1 = AssetAttribute(id='test_attribute1', value='attr1', type='Events', tag='test')
-        attribute2 = AssetAttribute(id='test_attribute2', value='attr1', type='Events', tag='test')
+        attribute2 = AssetAttribute(id='test_attribute2', value='attr2', type='Events', tag='test')
         self.app.add_attribute(attribute1)
         self.app.add_attribute(attribute2)
 
-        self.assertIn(attribute1, self.app._mocked_attributes)
-        self.assertIn(attribute2, self.app._mocked_attributes)
+        self.assertEqual(attribute1, self.app.test_attribute1)
+        self.assertEqual(attribute2, self.app.test_attribute2)
 
     def test_attributes(self):
         """ Test attributes() """
@@ -103,16 +103,6 @@ class TestOpenFactoryAppTestMode(TestCase):
         self.app.add_attribute(attr)
 
         self.assertIn({'ID': 'attribute', 'VALUE': 'some_value', 'TAG': 'test'}, self.app.events())
-
-    def test_get_mocked_attribute_by_id(self):
-        """ Test __get_mocked_attribute_by_id """
-        # Add an AssetAttribute
-        attr = AssetAttribute(id='attribute1', value='attr1', type='Events', tag='test')
-        self.app.add_attribute(attr)
-        self.assertEqual(self.app._get_mocked_attribute_by_id('attribute1'), attr)
-
-        # A none existing AssetAttribute should return None
-        self.assertEqual(self.app._get_mocked_attribute_by_id('does_not_exist'), None)
 
     def test_setattr_in_test_mode_bypasses_producer(self):
         """ Test AssetAttribute attributes """

--- a/tests/openfactory/assets/test_asset.py
+++ b/tests/openfactory/assets/test_asset.py
@@ -11,6 +11,27 @@ class TestAsset(TestCase):
     Test class Asset
     """
 
+    def setUp(self):
+        self.patcher_fetch_attributes = patch.object(BaseAsset, "_fetch_attributes")
+        self.patcher_fetch_methods = patch.object(BaseAsset, "_fetch_methods")
+        self.patcher_get_nats_cluster_url = patch(
+            "openfactory.assets.asset_base.get_nats_cluster_url",
+            return_value="nats://mock"
+        )
+        self.patcher_nats_subscriber = patch(
+            "openfactory.assets.asset_base.NATSSubscriber"
+        )
+
+        self.patcher_fetch_attributes.start()
+        self.patcher_fetch_methods.start()
+        self.patcher_get_nats_cluster_url.start()
+        self.patcher_nats_subscriber.start()
+
+        self.addCleanup(self.patcher_fetch_attributes.stop)
+        self.addCleanup(self.patcher_fetch_methods.stop)
+        self.addCleanup(self.patcher_get_nats_cluster_url.stop)
+        self.addCleanup(self.patcher_nats_subscriber.stop)
+
     def test_inherits_from_baseasset(self, MockAssetProducer):
         """ Test AssetUNS derives from BaseAsset """
         self.assertTrue(issubclass(Asset, BaseAsset))

--- a/tests/openfactory/assets/test_asset_test_mode.py
+++ b/tests/openfactory/assets/test_asset_test_mode.py
@@ -34,11 +34,12 @@ class TestAssetTestMode(TestCase):
         """ Test that add_attributes populates internal list in test_mode """
         # Add two AssetAttributes
         attribute1 = AssetAttribute(id='test_attribute1', value='attr1', type='Events', tag='test')
-        attribute2 = AssetAttribute(id='test_attribute2', value='attr1', type='Events', tag='test')
+        attribute2 = AssetAttribute(id='test_attribute2', value='attr2', type='Events', tag='test')
         self.asset.add_attribute(attribute1)
         self.asset.add_attribute(attribute2)
 
-        self.assertEqual(self.asset._mocked_attributes, [attribute1, attribute2])
+        self.assertEqual(self.asset.test_attribute1, attribute1)
+        self.assertEqual(self.asset.test_attribute2, attribute2)
 
     def test_attributes(self):
         """ Test attributes() """
@@ -77,15 +78,17 @@ class TestAssetTestMode(TestCase):
 
         self.assertEqual(self.asset.events(), [{'ID': 'attribute', 'VALUE': 'some_value', 'TAG': 'test'}])
 
-    def test_get_mocked_attribute_by_id(self):
-        """ Test __get_mocked_attribute_by_id """
-        # Add an AssetAttribute
-        attr = AssetAttribute(id='attribute1', value='attr1', type='Events', tag='test')
+    def test_get_attribute(self):
+        """ Test retrieving Asset attributes. """
+        attr = AssetAttribute(
+            id="attribute1",
+            value="attr1",
+            type="Events",
+            tag="test"
+        )
         self.asset.add_attribute(attr)
-        self.assertEqual(self.asset._get_mocked_attribute_by_id('attribute1'), attr)
 
-        # A none existing AssetAttribute should return None
-        self.assertEqual(self.asset._get_mocked_attribute_by_id('does_not_exist'), None)
+        self.assertIs(self.asset.attribute1, attr)
 
     def test_setattr_in_test_mode_bypasses_producer(self):
         """ Test AssetAttribute attributes """

--- a/tests/openfactory/assets/test_asset_uns_class.py
+++ b/tests/openfactory/assets/test_asset_uns_class.py
@@ -3,6 +3,7 @@ from unittest.mock import MagicMock, patch, call
 from openfactory.assets import AssetUNS
 from openfactory.assets.asset_base import BaseAsset
 from openfactory.kafka import KafkaAssetUNSConsumer
+from openfactory.exceptions import OFAException
 
 
 @patch("openfactory.assets.asset_base.AssetProducer")
@@ -10,6 +11,27 @@ class TestAssetUNS(unittest.TestCase):
     """
     Test class AssetUNS
     """
+
+    def setUp(self):
+        self.patcher_fetch_attributes = patch.object(BaseAsset, "_fetch_attributes")
+        self.patcher_fetch_methods = patch.object(BaseAsset, "_fetch_methods")
+        self.patcher_get_nats_cluster_url = patch(
+            "openfactory.assets.asset_base.get_nats_cluster_url",
+            return_value="nats://mock"
+        )
+        self.patcher_nats_subscriber = patch(
+            "openfactory.assets.asset_base.NATSSubscriber"
+        )
+
+        self.patcher_fetch_attributes.start()
+        self.patcher_fetch_methods.start()
+        self.patcher_get_nats_cluster_url.start()
+        self.patcher_nats_subscriber.start()
+
+        self.addCleanup(self.patcher_fetch_attributes.stop)
+        self.addCleanup(self.patcher_fetch_methods.stop)
+        self.addCleanup(self.patcher_get_nats_cluster_url.stop)
+        self.addCleanup(self.patcher_nats_subscriber.stop)
 
     def test_inherits_from_baseasset(self, MockAssetProducer):
         """ Test AssetUNS derives from BaseAsset """
@@ -40,21 +62,28 @@ class TestAssetUNS(unittest.TestCase):
         self.assertIn(call(expected_query), mock_ksqlClient.query.call_args_list)
         self.assertEqual(result, 'uuid-123')
 
-    def test_asset_uuid_returns_none_on_empty_df(self, MockAssetProducer):
-        """ Test asset_uuid is None when no mapping """
+    def test_asset_uuid_raises_when_mapping_missing(self, MockAssetProducer):
+        """Test AssetUNS raises when no UUID mapping exists."""
         mock_ksqlClient = MagicMock()
         mock_ksqlClient.query.return_value = []
-        asset = AssetUNS('test_uns_001', ksqlClient=mock_ksqlClient,
-                         bootstrap_servers='mocked_broker', asset_router_url='mocked_asset_url')
 
-        result = asset.asset_uuid
-        self.assertIsNone(result)
+        with self.assertRaises(OFAException) as cm:
+            AssetUNS(
+                "test_uns_001",
+                ksqlClient=mock_ksqlClient,
+                bootstrap_servers="mocked_broker",
+                asset_router_url="mocked_asset_url",
+            )
+
+        self.assertEqual(str(cm.exception), "No Asset UUID mapping found for UNS asset 'test_uns_001'.")
 
     def test_get_reference_list_returns_uuids(self, MockAssetProducer):
         """ Test _get_reference_list returns list of UUIDs """
         mock_ksqlClient = MagicMock()
         mock_ksqlClient.query.side_effect = [
-            [{'VALUE': 'ref_001, ref_002'}]  # references query
+            [{"ASSET_UUID": "uuid-123"}],        # __start_nats_consumer()
+            [{"ASSET_UUID": "uuid-123"}],        # self._subscribed_asset_uuid
+            [{"VALUE": "ref_001, ref_002"}],     # _get_reference_list()
         ]
 
         asset = AssetUNS('test_uns_001', ksqlClient=mock_ksqlClient,
@@ -69,7 +98,11 @@ class TestAssetUNS(unittest.TestCase):
         """ Test _get_reference_list returns empty list on empty query """
         mock_map = [{'ASSET_UUID': 'uuid-123'}]
         mock_ksqlClient = MagicMock()
-        mock_ksqlClient.query.side_effect = [mock_map, []]
+        mock_ksqlClient.query.side_effect = [
+            mock_map,   # __start_nats_consumer()
+            mock_map,   # self._subscribed_asset_uuid
+            [],         # _get_reference_list()
+        ]
 
         asset = AssetUNS('test_uns_001', ksqlClient=mock_ksqlClient,
                          bootstrap_servers='mocked_broker', asset_router_url='mocked_asset_url')
@@ -80,29 +113,90 @@ class TestAssetUNS(unittest.TestCase):
         """ Test _get_reference_list returns empty list on blank VALUE """
         mock_map = [{'ASSET_UUID': 'uuid-123'}]
         mock_ksqlClient = MagicMock()
-        mock_ksqlClient.query.side_effect = [mock_map, [{'VALUE': '   '}]]
+        mock_ksqlClient.query.side_effect = [
+            mock_map,                # __start_nats_consumer()
+            mock_map,                # self._subscribed_asset_uuid
+            [{"VALUE": "   "}],      # _get_reference_list()
+        ]
 
         asset = AssetUNS('test_uns_001', ksqlClient=mock_ksqlClient,
                          bootstrap_servers='mocked_broker', asset_router_url='mocked_asset_url')
         result = asset._get_reference_list('above')
         self.assertEqual(result, [])
 
-    @patch('openfactory.assets.asset_uns_class.AssetUNS')
+    @patch("openfactory.assets.asset_uns_class.AssetUNS")
     def test_get_reference_list_returns_assets(self, MockAssetUNS, MockAssetProducer):
-        """ Test _get_reference_list returns AssetUNS instances when as_assets=True """
+        """ Test _get_reference_list returns AssetUNS instances when as_assets=True. """
+
+        mock_map = [{"ASSET_UUID": "uuid-123"}]
+
         mock_ksqlClient = MagicMock()
-        mock_ksqlClient.query.side_effect = [[{'VALUE': 'uns_010, uns_020'}]]
+        mock_ksqlClient.query.side_effect = [
+            mock_map,                             # __start_nats_consumer()
+            mock_map,                             # self._subscribed_asset_uuid
+            [{"VALUE": "uns_010, uns_020"}],      # _get_reference_list()
+        ]
 
         # Setup return values for mocked AssetUNS constructor
         mock_asset_1 = MagicMock()
         mock_asset_2 = MagicMock()
         MockAssetUNS.side_effect = [mock_asset_1, mock_asset_2]
 
-        asset = AssetUNS('test_uns_001', ksqlClient=mock_ksqlClient,
-                         bootstrap_servers='mocked_broker', asset_router_url='mocked_asset_url')
-        result = asset._get_reference_list('below', as_assets=True)
+        asset = AssetUNS(
+            "test_uns_001",
+            ksqlClient=mock_ksqlClient,
+            bootstrap_servers="mocked_broker",
+            asset_router_url="mocked_asset_url",
+        )
+
+        result = asset._get_reference_list("below", as_assets=True)
 
         self.assertEqual(result, [mock_asset_1, mock_asset_2])
-        MockAssetUNS.assert_any_call('uns_010', ksqlClient=mock_ksqlClient)
-        MockAssetUNS.assert_any_call('uns_020', ksqlClient=mock_ksqlClient)
+        MockAssetUNS.assert_any_call("uns_010", ksqlClient=mock_ksqlClient)
+        MockAssetUNS.assert_any_call("uns_020", ksqlClient=mock_ksqlClient)
         self.assertEqual(MockAssetUNS.call_count, 2)
+
+    @patch.object(BaseAsset, "_restart_nats_subscription")
+    def test_check_asset_mapping_restarts_when_uuid_changes(self, mock_restart, MockAssetProducer):
+        mock_ksql = MagicMock()
+        mock_ksql.query.side_effect = [
+            [{"ASSET_UUID": "uuid-123"}],   # start_nats_consumer
+            [{"ASSET_UUID": "uuid-123"}],   # _subscribed_asset_uuid
+            [{"ASSET_UUID": "uuid-456"}],   # _check_asset_mapping
+        ]
+
+        asset = AssetUNS(
+            "test_uns_001",
+            ksqlClient=mock_ksql,
+            bootstrap_servers="mocked_broker",
+            asset_router_url="mocked_asset_url",
+            start_mapping_watcher=False,
+        )
+
+        asset._check_asset_mapping()
+
+        mock_restart.assert_called_once()
+        self.assertEqual(asset._subscribed_asset_uuid, "uuid-456")
+
+    @patch.object(BaseAsset, "_restart_nats_subscription")
+    def test_check_asset_mapping_does_nothing_when_uuid_unchanged(self, mock_restart, MockAssetProducer):
+        """ No restart should occur when the UUID mapping is unchanged. """
+        mock_ksql = MagicMock()
+        mock_ksql.query.side_effect = [
+            [{"ASSET_UUID": "uuid-123"}],   # start_nats_consumer
+            [{"ASSET_UUID": "uuid-123"}],   # _subscribed_asset_uuid
+            [{"ASSET_UUID": "uuid-123"}],   # _check_asset_mapping
+        ]
+
+        asset = AssetUNS(
+            "test_uns_001",
+            ksqlClient=mock_ksql,
+            bootstrap_servers="mocked_broker",
+            asset_router_url="mocked_asset_url",
+            start_mapping_watcher=False,
+        )
+
+        asset._check_asset_mapping()
+
+        mock_restart.assert_not_called()
+        self.assertEqual(asset._subscribed_asset_uuid, "uuid-123")

--- a/tests/openfactory/assets/test_asset_uns_test_mode.py
+++ b/tests/openfactory/assets/test_asset_uns_test_mode.py
@@ -34,11 +34,12 @@ class TestAssetUNSTestMode(TestCase):
         """ Test that add_attributes populates internal list in test_mode """
         # Add two AssetAttributes
         attribute1 = AssetAttribute(id='test_attribute1', value='attr1', type='Events', tag='test')
-        attribute2 = AssetAttribute(id='test_attribute2', value='attr1', type='Events', tag='test')
+        attribute2 = AssetAttribute(id='test_attribute2', value='attr2', type='Events', tag='test')
         self.asset.add_attribute(attribute1)
         self.asset.add_attribute(attribute2)
 
-        self.assertEqual(self.asset._mocked_attributes, [attribute1, attribute2])
+        self.assertEqual(self.asset.test_attribute1, attribute1)
+        self.assertEqual(self.asset.test_attribute2, attribute2)
 
     def test_attributes(self):
         """ Test attributes() """
@@ -76,16 +77,6 @@ class TestAssetUNSTestMode(TestCase):
         self.asset.add_attribute(attr)
 
         self.assertEqual(self.asset.events(), [{'ID': 'attribute', 'VALUE': 'some_value', 'TAG': 'test'}])
-
-    def test_get_mocked_attribute_by_id(self):
-        """ Test __get_mocked_attribute_by_id """
-        # Add an AssetAttribute
-        attr = AssetAttribute(id='attribute1', value='attr1', type='Events', tag='test')
-        self.asset.add_attribute(attr)
-        self.assertEqual(self.asset._get_mocked_attribute_by_id('attribute1'), attr)
-
-        # A none existing AssetAttribute should return None
-        self.assertEqual(self.asset._get_mocked_attribute_by_id('does_not_exist'), None)
 
     def test_setattr_in_test_mode_bypasses_producer(self):
         """ Test AssetAttribute attributes """

--- a/tests/openfactory/assets/test_baseasset.py
+++ b/tests/openfactory/assets/test_baseasset.py
@@ -1,7 +1,9 @@
 import json
+import threading
 from unittest import TestCase
 from unittest.mock import Mock, MagicMock, patch
 from datetime import datetime
+from operator import gt
 from openfactory.exceptions import OFAException
 from openfactory.kafka import KSQLDBClient
 from openfactory.assets import AssetAttribute
@@ -51,8 +53,16 @@ class TestBaseAsset(TestCase):
         self.MockNATSSubscriber = nats_patcher.start()
         self.addCleanup(nats_patcher.stop)
 
+        url_patcher = patch(
+            "openfactory.assets.asset_base.get_nats_cluster_url",
+            return_value="nats://mocked_cluster"
+        )
+        self.mock_get_nats_cluster_url = url_patcher.start()
+        self.addCleanup(url_patcher.stop)
+
     def test_valid_subclass(self, MockAssetProducer):
         """ Test valid subclass """
+        self.ksql_mock.query.return_value = []
         asset = ValidAsset('some_id', self.ksql_mock)
         self.assertEqual(asset.ksql, self.ksql_mock)
         self.assertEqual(asset.bootstrap_servers, 'MockedBroker')
@@ -66,6 +76,7 @@ class TestBaseAsset(TestCase):
 
     def test_asset_router_url_explicit(self, MockAssetProducer):
         """ Test explicite definition of asset_router_url """
+        self.ksql_mock.query.return_value = []
         asset = ValidAsset(
             "some_id",
             self.ksql_mock,
@@ -77,6 +88,7 @@ class TestBaseAsset(TestCase):
     @patch.dict("os.environ", {"ASSET_ROUTER_URL": "http://env-router"})
     def test_asset_router_url_from_env(self, MockAssetProducer):
         """ Test environment variable fallback for asset_router_url """
+        self.ksql_mock.query.return_value = []
         asset = ValidAsset("some_id", self.ksql_mock, asset_router_url=None)
 
         self.assertEqual(asset.asset_router_url, "http://env-router")
@@ -91,6 +103,7 @@ class TestBaseAsset(TestCase):
 
     def test_bootstrap_servers_explicit(self, MockAssetProducer):
         """ Test explicite definition of bootstrap_servers """
+        self.ksql_mock.query.return_value = []
         asset = ValidAsset(
             "some_id",
             self.ksql_mock,
@@ -102,6 +115,7 @@ class TestBaseAsset(TestCase):
     @patch.dict("os.environ", {"KAFKA_BROKER": "mocked-broker"})
     def test_bootstrap_servers_from_env(self, MockAssetProducer):
         """ Test environment variable fallback for bootstrap_servers """
+        self.ksql_mock.query.return_value = []
         asset = ValidAsset("some_id", self.ksql_mock, bootstrap_servers=None)
 
         self.assertEqual(asset.bootstrap_servers, "mocked-broker")
@@ -163,23 +177,16 @@ class TestBaseAsset(TestCase):
         with self.assertRaises(TypeError):
             InvalidConsumer('some_id', self.ksql_mock)
 
-    def test_close_stops_all_subscribers(self, MockAssetProducer):
-        """ Test close stops all NATS subscribers """
+    def test_close_stops_subscriber(self, MockAssetProducer):
+        """ Test close() stops the asset's NATS subscriber. """
         asset = ValidAsset("uuid-123", ksqlClient=MagicMock())
 
-        # Register fake subscribers
-        mock_sub1 = MagicMock()
-        mock_sub2 = MagicMock()
-        asset.subscribers = {"s1": mock_sub1, "s2": mock_sub2}
-
-        # Patch loop thread functions to avoid real async interaction
+        asset._subscriber = MagicMock()
         asset.loop_thread.stop = MagicMock()
 
         asset.close()
 
-        mock_sub1.stop.assert_called_once()
-        mock_sub2.stop.assert_called_once()
-        self.assertEqual(asset.subscribers, {})  # should be cleared
+        asset._subscriber.stop.assert_called_once()
 
     @patch("asyncio.all_tasks")
     @patch("asyncio.gather")
@@ -208,6 +215,292 @@ class TestBaseAsset(TestCase):
 
         asset.loop_thread.stop.assert_called_once()
 
+    def test_parse_method_value_none(self, MockAssetProducer):
+        """ Test _parse_method_value returns None unchanged. """
+        asset = ValidAsset("uuid-123", ksqlClient=MagicMock())
+        self.assertIsNone(asset._parse_method_value(None))
+
+    def test_parse_method_value_dict(self, MockAssetProducer):
+        """ Test _parse_method_value returns dictionaries unchanged. """
+        asset = ValidAsset("uuid-123", ksqlClient=MagicMock())
+
+        payload = {
+            "description": "GenerateCode",
+            "arguments": [],
+        }
+
+        self.assertIs(asset._parse_method_value(payload), payload)
+
+    def test_parse_method_value_json(self, MockAssetProducer):
+        """ Test _parse_method_value parses valid JSON strings. """
+        asset = ValidAsset("uuid-123", ksqlClient=MagicMock())
+
+        payload = {
+            "description": "GenerateCode",
+            "arguments": [],
+        }
+
+        self.assertEqual(asset._parse_method_value(json.dumps(payload)), payload)
+
+    def test_parse_method_value_invalid_json(self, MockAssetProducer):
+        """ Test _parse_method_value returns invalid JSON strings unchanged. """
+        asset = ValidAsset("uuid-123", ksqlClient=MagicMock())
+        self.assertEqual(asset._parse_method_value("not json"), "not json")
+
+    def test_parse_method_value_other_type(self, MockAssetProducer):
+        """ Test _parse_method_value returns unsupported types unchanged. """
+        asset = ValidAsset("uuid-123", ksqlClient=MagicMock())
+        self.assertEqual(asset._parse_method_value(42), 42)
+
+    def test_on_message_updates_attribute_cache(self, MockAssetProducer):
+        """ Test _on_message updates the cached AssetAttribute. """
+
+        asset = ValidAsset("uuid-123", ksqlClient=MagicMock())
+
+        asset._on_message(
+            f"{asset.asset_uuid.upper()}.temperature",
+            {
+                "TYPE": "Samples",
+                "VALUE": 42,
+                "TAG": "Temperature",
+                "attributes": {"timestamp": "MockedTimeStamp"},
+            },
+        )
+
+        self.assertEqual(asset.temperature.value, 42)
+        self.assertEqual(asset.temperature.tag, "Temperature")
+        self.assertEqual(asset.temperature.type, "Samples")
+
+    def test_on_message_updates_method_definition(self, MockAssetProducer):
+        """ Test _on_message updates cached methods. """
+
+        asset = ValidAsset("uuid-123", ksqlClient=MagicMock())
+
+        payload = {
+            "description": "Generate code",
+            "arguments": []
+        }
+
+        asset._on_message(
+            f"{asset.asset_uuid.upper()}.GenerateCode",
+            {
+                "TYPE": "Method",
+                "VALUE": json.dumps(payload),
+            },
+        )
+
+        self.assertEqual(asset.methods()["GenerateCode"], payload)
+
+    def test_on_message_updates_method_definition_from_string(self, MockAssetProducer):
+        """ Test _on_message keeps invalid JSON method definitions as strings. """
+        asset = ValidAsset("uuid-123", ksqlClient=MagicMock())
+
+        asset._on_message(
+            f"{asset.asset_uuid.upper()}.GenerateCode",
+            {
+                "TYPE": "Method",
+                "VALUE": "not json",
+            },
+        )
+
+        self.assertEqual(asset.methods()["GenerateCode"], "not json")
+
+    def test_on_message_updates_method_definition_from_dict(self, MockAssetProducer):
+        """ Test _on_message accepts already parsed method definitions. """
+        asset = ValidAsset("uuid-123", ksqlClient=MagicMock())
+
+        payload = {
+            "description": "GenerateCode",
+            "arguments": []
+        }
+
+        asset._on_message(
+            f"{asset.asset_uuid.upper()}.GenerateCode",
+            {
+                "TYPE": "Method",
+                "VALUE": payload,
+            },
+        )
+
+        self.assertIs(asset.methods()["GenerateCode"], payload)
+
+    def test_on_message_replaces_existing_method_definition(self, MockAssetProducer):
+        """ Test _on_message replaces an existing cached method definition. """
+
+        asset = ValidAsset("uuid-123", ksqlClient=MagicMock())
+
+        asset.ofa_methods["GenerateCode"] = {
+            "description": "Old description",
+            "arguments": ["old"],
+        }
+
+        payload = {
+            "description": "New description",
+            "arguments": [],
+        }
+
+        asset._on_message(
+            f"{asset.asset_uuid.upper()}.GenerateCode",
+            {
+                "TYPE": "Method",
+                "VALUE": json.dumps(payload),
+            },
+        )
+
+        self.assertEqual(asset.methods()["GenerateCode"], payload)
+
+    def test_on_message_ignores_unknown_message_type(self, MockAssetProducer):
+        """ Test _on_message ignores unsupported message types. """
+
+        asset = ValidAsset("uuid-123", ksqlClient=MagicMock())
+
+        attr = AssetAttribute(
+            id="temperature",
+            value=42,
+            type="Samples",
+            tag="Temperature",
+        )
+
+        asset.ofa_attributes["temperature"] = attr
+
+        asset.ofa_methods["GenerateCode"] = {
+            "description": "GenerateCode",
+            "arguments": [],
+        }
+
+        asset._on_message(
+            f"{asset.asset_uuid.upper()}.temperature",
+            {
+                "TYPE": "SomethingUnexpected",
+                "VALUE": "new value",
+                "TAG": "Temperature",
+                "attributes": {"timestamp": "MockedTimeStamp"},
+            },
+        )
+
+        self.assertIs(asset.ofa_attributes["temperature"], attr)
+
+        self.assertEqual(
+            asset.ofa_methods["GenerateCode"],
+            {
+                "description": "GenerateCode",
+                "arguments": [],
+            },
+        )
+
+    def test_fetch_attributes_converts_samples_to_float(self, MockAssetProducer):
+        """ Test _fetch_attributes converts sample values to float. """
+
+        ksqlMock = MagicMock()
+
+        def query_side_effect(query):
+            if "TYPE != 'Method'" in query:
+                return [{
+                    "ID": "temperature",
+                    "VALUE": "42.5",
+                    "TYPE": "Samples",
+                    "TAG": "Temperature",
+                    "TIMESTAMP": "MockedTimeStamp",
+                }]
+
+            if "TYPE='Method'" in query:
+                return []
+
+            return []
+
+        ksqlMock.query.side_effect = query_side_effect
+
+        asset = ValidAsset("uuid-123", ksqlClient=ksqlMock)
+
+        self.assertEqual(asset.temperature.value, 42.5)
+        self.assertIsInstance(asset.temperature.value, float)
+
+    def test_fetch_methods_parses_json(self, MockAssetProducer):
+        """ Test _fetch_methods parses JSON method definitions. """
+
+        ksqlMock = MagicMock()
+
+        def query_side_effect(query):
+            if "TYPE != 'Method'" in query:
+                return []
+
+            if "TYPE='Method'" in query:
+                return [{
+                    "ID": "GenerateCode",
+                    "VALUE": json.dumps({
+                        "description": "GenerateCode",
+                        "arguments": []
+                    }),
+                    "TYPE": "Method",
+                }]
+
+            return []
+
+        ksqlMock.query.side_effect = query_side_effect
+
+        asset = ValidAsset("uuid-123", ksqlClient=ksqlMock)
+
+        self.assertEqual(
+            asset.methods()["GenerateCode"],
+            {
+                "description": "GenerateCode",
+                "arguments": []
+            }
+        )
+
+    def test_fetch_methods_accepts_dict(self, MockAssetProducer):
+        """ Test _fetch_methods accepts already parsed method definitions. """
+
+        payload = {
+            "description": "GenerateCode",
+            "arguments": []
+        }
+
+        ksqlMock = MagicMock()
+
+        def query_side_effect(query):
+            if "TYPE != 'Method'" in query:
+                return []
+
+            if "TYPE='Method'" in query:
+                return [{
+                    "ID": "GenerateCode",
+                    "VALUE": payload,
+                    "TYPE": "Method",
+                }]
+
+            return []
+
+        ksqlMock.query.side_effect = query_side_effect
+
+        asset = ValidAsset("uuid-123", ksqlClient=ksqlMock)
+
+        self.assertIs(asset.methods()["GenerateCode"], payload)
+
+    def test_fetch_methods_accepts_none(self, MockAssetProducer):
+        """ Test _fetch_methods stores None method definitions. """
+
+        ksqlMock = MagicMock()
+
+        def query_side_effect(query):
+            if "TYPE != 'Method'" in query:
+                return []
+
+            if "TYPE='Method'" in query:
+                return [{
+                    "ID": "GenerateCode",
+                    "VALUE": None,
+                    "TYPE": "Method",
+                }]
+
+            return []
+
+        ksqlMock.query.side_effect = query_side_effect
+
+        asset = ValidAsset("uuid-123", ksqlClient=ksqlMock)
+
+        self.assertIsNone(asset.methods()["GenerateCode"])
+
     def test_type_returns_unavailable_when_empty(self, MockAssetProducer):
         """ Test if asset.type returns 'UNAVAILABLE' when the ksql query yields no results """
 
@@ -221,14 +514,20 @@ class TestBaseAsset(TestCase):
 
         # Check if the correct query was executed
         expected_query = "SELECT TYPE FROM assets_type WHERE ASSET_UUID='some_id';"
-        self.ksql_mock.query.assert_called_once_with(expected_query)
+        self.ksql_mock.query.assert_any_call(expected_query)
 
     def test_type_returns_value_when_present(self, MockAssetProducer):
         """ Test if asset.type returns the correct value when the ksql query returns data """
 
         # Simulate a valid result from ksqlDB with type 'Condition'
         ksql_mock = Mock(spec=KSQLDBClient)
-        ksql_mock.query.return_value = [{'TYPE': 'Condition'}]
+
+        def query_side_effect(query):
+            if query.startswith("SELECT TYPE FROM assets_type"):
+                return [{"TYPE": "Condition"}]
+            return []
+
+        ksql_mock.query.side_effect = query_side_effect
 
         asset = ValidAsset('some_id', ksql_mock)
 
@@ -237,15 +536,33 @@ class TestBaseAsset(TestCase):
 
         # Check if the correct query was executed
         expected_query = "SELECT TYPE FROM assets_type WHERE ASSET_UUID='some_id';"
-        ksql_mock.query.assert_called_once_with(expected_query)
+        ksql_mock.query.assert_any_call(expected_query)
 
     def test_attributes_success(self, MockAssetProducer):
         """ Test attributes() returns correct attribute IDs """
         ksqlMock = MagicMock()
         ksqlMock.query.return_value = [
-            {"ID": 101},
-            {"ID": 102},
-            {"ID": 103}
+            {
+                "ID": 101,
+                "VALUE": 1,
+                "TYPE": "Samples",
+                "TAG": "Temperature",
+                "TIMESTAMP": "MockedTimeStamp",
+            },
+            {
+                "ID": 102,
+                "VALUE": 2,
+                "TYPE": "Events",
+                "TAG": "Execution",
+                "TIMESTAMP": "MockedTimeStamp",
+            },
+            {
+                "ID": 103,
+                "VALUE": 3,
+                "TYPE": "Condition",
+                "TAG": "Fault",
+                "TIMESTAMP": "MockedTimeStamp",
+            },
         ]
 
         asset = ValidAsset("uuid-123", ksqlClient=ksqlMock)
@@ -270,18 +587,23 @@ class TestBaseAsset(TestCase):
             {
                 "ID": "id1",
                 "VALUE": "val1",
-                "TAG": "{urn:mtconnect.org:MTConnectStreams:2.2}MockedTag"
-            }
+                "TYPE": "Samples",
+                "TAG": "{urn:mtconnect.org:MTConnectStreams:2.2}MockedTag",
+                "TIMESTAMP": "MockedTimeStamp",
+            },
+            {
+                "ID": "id2",
+                "VALUE": "val2",
+                "TYPE": "Events",
+                "TAG": "Execution",
+                "TIMESTAMP": "MockedTimeStamp",
+            },
         ]
 
         asset = ValidAsset("uuid-123", ksqlClient=ksqlMock)
         samples = asset._get_attributes_by_type('Samples')
 
         self.assertEqual(samples, [{'ID': 'id1', 'VALUE': 'val1', 'TAG': 'MockedTag'}])
-
-        # Ensure correct query was executed
-        expected_query = f"SELECT ID, VALUE, TAG, TYPE FROM {asset.KSQL_ASSET_TABLE} WHERE {asset.KSQL_ASSET_ID}='{asset.ASSET_ID}' AND TYPE='Samples';"
-        ksqlMock.query.assert_any_call(expected_query)
 
     def test_samples(self, MockAssetProducer):
         """ Test samples() """
@@ -290,8 +612,17 @@ class TestBaseAsset(TestCase):
             {
                 "ID": "id1",
                 "VALUE": "val1",
-                "TAG": "{urn:mtconnect.org:MTConnectStreams:2.2}MockedTag"
-            }
+                "TYPE": "Samples",
+                "TAG": "{urn:mtconnect.org:MTConnectStreams:2.2}MockedTag",
+                "TIMESTAMP": "MockedTimeStamp",
+            },
+            {
+                "ID": "event1",
+                "VALUE": "ACTIVE",
+                "TYPE": "Events",
+                "TAG": "Execution",
+                "TIMESTAMP": "MockedTimeStamp",
+            },
         ]
 
         asset = ValidAsset("uuid-123", ksqlClient=ksqlMock)
@@ -299,18 +630,23 @@ class TestBaseAsset(TestCase):
 
         self.assertEqual(samples, [{'ID': 'id1', 'VALUE': 'val1', 'TAG': 'MockedTag'}])
 
-        # Ensure correct query was executed
-        expected_query = f"SELECT ID, VALUE, TAG, TYPE FROM {asset.KSQL_ASSET_TABLE} WHERE {asset.KSQL_ASSET_ID}='{asset.ASSET_ID}' AND TYPE='Samples';"
-        ksqlMock.query.assert_any_call(expected_query)
-
     def test_events(self, MockAssetProducer):
         """ Test events() """
         ksqlMock = MagicMock()
         ksqlMock.query.return_value = [
             {
+                "ID": "id1",
+                "VALUE": "val1",
+                "TYPE": "Samples",
+                "TAG": "{urn:mtconnect.org:MTConnectStreams:2.2}MockedTag",
+                "TIMESTAMP": "MockedTimeStamp",
+            },
+            {
                 "ID": "id2",
                 "VALUE": "val2",
-                "TAG": "{urn:mtconnect.org:MTConnectStreams:2.2}MockedTag"
+                "TYPE": "Events",
+                "TAG": "{urn:mtconnect.org:MTConnectStreams:2.2}MockedTag",
+                "TIMESTAMP": "MockedTimeStamp",
             }
         ]
 
@@ -319,10 +655,6 @@ class TestBaseAsset(TestCase):
 
         self.assertEqual(events, [{'ID': 'id2', 'VALUE': 'val2', 'TAG': 'MockedTag'}])
 
-        # Ensure correct query was executed
-        expected_query = f"SELECT ID, VALUE, TAG, TYPE FROM {asset.KSQL_ASSET_TABLE} WHERE {asset.KSQL_ASSET_ID}='{asset.ASSET_ID}' AND TYPE='Events';"
-        ksqlMock.query.assert_any_call(expected_query)
-
     def test_conditions(self, MockAssetProducer):
         """ Test conditions() """
         ksqlMock = MagicMock()
@@ -330,8 +662,17 @@ class TestBaseAsset(TestCase):
             {
                 "ID": "id3",
                 "VALUE": "val3",
-                "TAG": "{urn:mtconnect.org:MTConnectStreams:2.2}Fault"
-            }
+                "TYPE": "Condition",
+                "TAG": "{urn:mtconnect.org:MTConnectStreams:2.2}Fault",
+                "TIMESTAMP": "MockedTimeStamp",
+            },
+            {
+                "ID": "id4",
+                "VALUE": "val4",
+                "TYPE": "Samples",
+                "TAG": "Temperature",
+                "TIMESTAMP": "MockedTimeStamp",
+            },
         ]
 
         asset = ValidAsset("uuid-123", ksqlClient=ksqlMock)
@@ -344,25 +685,23 @@ class TestBaseAsset(TestCase):
         }]
         self.assertEqual(conditions, expected_conditions)
 
-        # Ensure correct query was exectued
-        expected_query = f"SELECT ID, VALUE, TAG, TYPE FROM {asset.KSQL_ASSET_TABLE} WHERE {asset.KSQL_ASSET_ID}='{asset.ASSET_ID}' AND TYPE='Condition';"
-        ksqlMock.query.assert_any_call(expected_query)
-
     def test_methods(self, MockAssetProducer):
         """ Test methods() """
         ksqlMock = MagicMock()
-        ksqlMock.query.return_value = [
-            {"ID": "id4", "VALUE": "val4"}
-        ]
+
+        def query_side_effect(query):
+            if "TYPE != 'Method'" in query:
+                return []
+            elif "TYPE='Method'" in query:
+                return [{"ID": "id4", "VALUE": "val4"}]
+            return []
+
+        ksqlMock.query.side_effect = query_side_effect
 
         asset = ValidAsset("uuid-123", ksqlClient=ksqlMock)
         methods = asset.methods()
 
         self.assertEqual(methods, {'id4': 'val4'})
-
-        # Ensure correct query was exectued
-        expected_query = f"SELECT ID, VALUE, TYPE FROM {asset.KSQL_ASSET_TABLE} WHERE {asset.KSQL_ASSET_ID}='{asset.ASSET_ID}' AND TYPE='Method';"
-        ksqlMock.query.assert_any_call(expected_query)
 
     def test_method_builds_correct_envelope(self, MockAssetProducer):
         """ Test that method() builds and sends a valid CommandEnvelope """
@@ -404,6 +743,19 @@ class TestBaseAsset(TestCase):
         asset.new_attr = "something"
         self.assertEqual(asset.new_attr, "something")
 
+    def test_setattr_method_raises_exception(self, MockAssetProducer):
+        """ Test assigning to a method raises OFAException. """
+
+        asset = ValidAsset("uuid-123", ksqlClient=MagicMock())
+
+        asset.ofa_methods["GenerateCode"] = {
+            "description": "GenerateCode",
+            "arguments": []
+        }
+
+        with self.assertRaises(OFAException):
+            asset.GenerateCode = 42
+
     def test_setattr_raises_exception_on_invalid_asset_attribute(self, MockAssetProducer):
         """ Test setting an AssetAttribute on undefined asset attribute raises exception """
         # Mock asset with a single 'temperature' attribute
@@ -421,12 +773,18 @@ class TestBaseAsset(TestCase):
         """ Test setting a defined asset attribute with AssetAttribute instance """
         mock_producer = MockAssetProducer.return_value
         asset = ValidAsset("uuid-123", ksqlClient=MagicMock(), bootstrap_servers="mock_broker")
-        asset.attributes = MagicMock(return_value=["temperature"])
+        asset.ofa_attributes["temperature"] = AssetAttribute(
+            id="temperature",
+            value=None,
+            tag="Temperature",
+            type="Samples",
+        )
 
         attr = AssetAttribute(id='temperature', value=25, tag="Temperature", type="Samples")
         asset.temperature = attr
 
         mock_producer.send_asset_attribute.assert_called_once_with("uuid-123", attr)
+        self.assertIs(asset.ofa_attributes["temperature"], attr)
 
     def test_setattr_with_wrong_asset_attribute_id(self, MockAssetProducer):
         """ Test setting a defined asset attribute with AssetAttribute instance having wrong id raises exception """
@@ -455,22 +813,14 @@ class TestBaseAsset(TestCase):
         )
         self.assertEqual(attribute, expected)
 
-        # Ensure correct query was executed
-        expected_query = (
-            "SELECT VALUE, TYPE, TAG, TIMESTAMP "
-            "FROM assets WHERE key='uuid-123|some_missing_attribute';"
-        )
-        ksqlMock.query.assert_any_call(expected_query)
-
     def test_setattr_valid_asset_attribute_with_raw_value(self, MockAssetProducer):
         """ Test setting a defined asset attribute with a raw value (not an AssetAttribute) """
         mock_producer = MockAssetProducer.return_value
         asset = ValidAsset("uuid-123", ksqlClient=MagicMock(), bootstrap_servers="mock_broker")
-        asset.attributes = MagicMock(return_value=["temperature"])
 
-        # Simulate current attribute with metadata
+        # Simulate current attribute
         current_attr = AssetAttribute(id="temperature", value=10, tag="Temperature", type="Samples")
-        asset.__getattr__ = MagicMock(return_value=current_attr)
+        asset.ofa_attributes["temperature"] = current_attr
 
         asset.temperature = 30
 
@@ -478,18 +828,34 @@ class TestBaseAsset(TestCase):
         expected = AssetAttribute(id="temperature", value=30, tag="Temperature", type="Samples")
         mock_producer.send_asset_attribute.assert_called_once_with("uuid-123", expected)
 
+        updated = asset.ofa_attributes["temperature"]
+        self.assertEqual(updated.id, "temperature")
+        self.assertEqual(updated.value, 30)
+        self.assertEqual(updated.tag, current_attr.tag)
+        self.assertEqual(updated.type, current_attr.type)
+
     def test_getattr_samples(self, MockAssetProducer):
         """ Test __getattr__ returns float for 'Samples' type """
         ksqlMock = MagicMock()
-        ksqlMock.query.return_value = [
-            {
-                "ID": "id1",
-                "VALUE": "42.5",
-                "TYPE": "Samples",
-                "TAG": "MockedTag",
-                "TIMESTAMP": "MockedTimeStamp"
-            }
-        ]
+
+        def query_side_effect(query):
+            if "TYPE != 'Method'" in query:
+                return [
+                    {
+                        "ID": "id1",
+                        "VALUE": "42.5",
+                        "TYPE": "Samples",
+                        "TAG": "MockedTag",
+                        "TIMESTAMP": "MockedTimeStamp",
+                    }
+                ]
+
+            if "TYPE='Method'" in query:
+                return []
+
+            return []
+
+        ksqlMock.query.side_effect = query_side_effect
 
         asset = ValidAsset("uuid-123", ksqlClient=ksqlMock)
         attribute = asset.id1
@@ -497,32 +863,34 @@ class TestBaseAsset(TestCase):
         expected = AssetAttribute(id='id1', value=42.5, type='Samples', tag='MockedTag', timestamp='MockedTimeStamp')
         self.assertEqual(attribute, expected)
 
-        # Ensure correct query was exectued
-        expected_query = "SELECT VALUE, TYPE, TAG, TIMESTAMP FROM assets WHERE key='uuid-123|id1';"
-        ksqlMock.query.assert_any_call(expected_query)
-
     def test_getattr_string_value(self, MockAssetProducer):
         """ Test __getattr__ returns raw VALUE for non-'Samples' and non-'Method' types """
         ksqlMock = MagicMock()
-        ksqlMock.query.return_value = [
-            {
-                "ID": "id2",
-                "VALUE": "val2",
-                "TYPE": "Events",
-                "TAG": "MockedTag",
-                "TIMESTAMP": "MockedTimeStamp"
-            }
-        ]
+
+        def query_side_effect(query):
+            if "TYPE != 'Method'" in query:
+                return [
+                    {
+                        "ID": "id2",
+                        "VALUE": "val2",
+                        "TYPE": "Events",
+                        "TAG": "MockedTag",
+                        "TIMESTAMP": "MockedTimeStamp"
+                    }
+                ]
+
+            if "TYPE='Method'" in query:
+                return []
+
+            return []
+
+        ksqlMock.query.side_effect = query_side_effect
 
         asset = ValidAsset("uuid-123", ksqlClient=ksqlMock)
         attribute = asset.id2
 
         expected = AssetAttribute(id='id2', value='val2', type='Events', tag='MockedTag', timestamp='MockedTimeStamp')
         self.assertEqual(attribute, expected)
-
-        # Ensure correct query was exectued
-        expected_query = "SELECT VALUE, TYPE, TAG, TIMESTAMP FROM assets WHERE key='uuid-123|id2';"
-        ksqlMock.query.assert_any_call(expected_query)
 
     @patch("openfactory.assets.asset_base.BaseAsset.method")
     def test_getattr_method(self, mock_method, MockAssetProducer):
@@ -554,10 +922,6 @@ class TestBaseAsset(TestCase):
         expected_args_list = [("arg1", "value1"), ("arg2", "value2")]
         mock_method.assert_called_once_with("a_method", "TEST-ASSET", expected_args_list)
 
-        # Ensure the correct KSQL query was executed
-        expected_query = "SELECT VALUE, TYPE, TAG, TIMESTAMP FROM assets WHERE key='uuid-123|a_method';"
-        ksqlMock.query.assert_any_call(expected_query)
-
     def test_add_attribute_sends_asset_attribute(self, MockAssetProducer):
         """ Test add_attribute sends the new AssetAttribute to the producer """
         asset = ValidAsset("uuid-123", ksqlClient=MagicMock())
@@ -573,8 +937,25 @@ class TestBaseAsset(TestCase):
 
         asset.producer.send_asset_attribute.assert_called_once_with("uuid-123", attr)
 
-    def test_add_attribute_in_test_mode_adds_to_mocked_attributes(self, MockAssetProducer):
-        """ Test add_attribute stores the attribute locally when in test mode """
+    def test_add_attribute_updates_cache_immediately(self, MockAssetProducer):
+        """ Test add_attribute immediately updates the local cache. """
+
+        asset = ValidAsset("uuid-123", ksqlClient=MagicMock())
+        asset.wait_until = MagicMock(return_value=True)
+
+        attr = AssetAttribute(
+            id="temperature",
+            value=42,
+            type="Samples",
+            tag="Temperature",
+        )
+
+        asset.add_attribute(attr)
+
+        self.assertIs(asset.temperature, attr)
+
+    def test_add_attribute_in_test_mode_adds_attribute(self, MockAssetProducer):
+        """ Test add_attribute stores the attribute locally in test mode. """
         asset = ValidAsset.__new__(ValidAsset)
         BaseAsset.__init__(asset, ksqlClient=MagicMock(), test_mode=True)
 
@@ -587,7 +968,9 @@ class TestBaseAsset(TestCase):
 
         asset.add_attribute(attr)
 
-        self.assertIn(attr, asset._mocked_attributes)
+        self.assertEqual(asset.temperature.value, 42)
+        self.assertEqual(asset.temperature.type, "Samples")
+        self.assertEqual(asset.temperature.tag, "Temperature")
 
     def test_add_attribute_waits_until_available_by_default(self, MockAssetProducer):
         """ Test add_attribute waits until the new attribute is available by default """
@@ -627,8 +1010,22 @@ class TestBaseAsset(TestCase):
 
     def test_get_reference_list_not_implemented(self, MockAssetProducer):
         """ Test if _get_reference_list raises NotImplementedError when not implemented in subclass """
+        def query_side_effect(query):
+            if "TYPE != 'Method'" in query:
+                return []
 
-        asset = ValidAsset('some_id', self.ksql_mock)
+            if "TYPE='Method'" in query:
+                return []
+
+            if "SELECT VALUE FROM assets WHERE key=" in query:
+                return [{"VALUE": "existing_ref"}]
+
+            return []
+
+        ksqlMock = MagicMock()
+        ksqlMock.query.side_effect = query_side_effect
+
+        asset = ValidAsset('some_id', ksqlClient=ksqlMock)
 
         with self.assertRaises(NotImplementedError):
             asset._get_reference_list('above')
@@ -722,8 +1119,21 @@ class TestBaseAsset(TestCase):
 
     def test_add_reference_above_with_existing_reference(self, MockAssetProducer):
         """ Test add_reference_above when existing references are present """
+        def query_side_effect(query):
+            if "TYPE != 'Method'" in query:
+                return []
+
+            if "TYPE='Method'" in query:
+                return []
+
+            if "SELECT VALUE FROM assets WHERE key='asset-001|references_above';" in query:
+                return [{"VALUE": "existing-ref1, existing-ref2"}]
+
+            return []
+
         ksqlMock = MagicMock()
-        ksqlMock.query.return_value = [{"VALUE": "existing-ref1, existing-ref2", "ID": "ID1"}]
+        ksqlMock.query.side_effect = query_side_effect
+
         asset = ValidAsset("asset-001", ksqlClient=ksqlMock)
         asset.producer = MagicMock()
 
@@ -768,8 +1178,24 @@ class TestBaseAsset(TestCase):
 
     def test_add_reference_below_with_existing_reference(self, MockAssetProducer):
         """ Test add_reference_below when existing references are present """
+        def query_side_effect(query):
+            if "TYPE != 'Method'" in query:
+                return []
+
+            if "TYPE='Method'" in query:
+                return []
+
+            if "references_above" in query:
+                return [{"VALUE": "existing-ref1, existing-ref2"}]
+
+            if "references_below" in query:
+                return [{"VALUE": "existing-ref1, existing-ref2"}]
+
+            return []
+
         ksqlMock = MagicMock()
-        ksqlMock.query.return_value = [{"VALUE": "existing-ref1, existing-ref2", "ID": "ID1"}]
+        ksqlMock.query.side_effect = query_side_effect
+
         asset = ValidAsset("asset-001", ksqlClient=ksqlMock)
         asset.producer = MagicMock()
 
@@ -789,25 +1215,19 @@ class TestBaseAsset(TestCase):
         )
         asset.producer.send_asset_attribute.assert_called_once_with("asset-001", expected_attr)
 
-    def test_wait_until_callable_attribute(self, MockAssetProducer):
-        """ Test wait_until returns True when the attribute is an OpenFactory method """
+    def test_wait_until_method_raises(self, MockAssetProducer):
+        """ wait_until cannot be used on methods. """
         asset = ValidAsset("test_uuid", ksqlClient=MagicMock())
 
-        def mock_method(**kwargs):
-            pass
+        asset.ofa_methods["test_method"] = {}
 
-        asset.__getattr__ = MagicMock(return_value=mock_method)
-
-        result = asset.wait_until(attribute_id="test_method", value=None)
-
-        self.assertTrue(result)
-        asset.__getattr__.assert_called_once_with("test_method")
+        with self.assertRaises(OFAException):
+            asset.wait_until(attribute_id="test_method", value=None)
 
     def test_wait_until_attribute_matches_initially(self, MockAssetProducer):
         """ Test wait_until returns True when the attribute matches initially """
         asset = ValidAsset("test_uuid", ksqlClient=MagicMock())
 
-        # Attribute already available in ksqlDB with the expected value
         attribute = AssetAttribute(
             id="test_attribute",
             value="expected_value",
@@ -815,127 +1235,165 @@ class TestBaseAsset(TestCase):
             tag="TestAttribute",
             timestamp="MockedTimeStamp",
         )
-        asset.__getattr__ = MagicMock(return_value=attribute)
+        asset.ofa_attributes["test_attribute"] = attribute
 
         result = asset.wait_until(attribute_id="test_attribute", value="expected_value")
 
         self.assertTrue(result)
-        asset.__getattr__.assert_called_once_with("test_attribute")
+
+    def test_wait_until_initial_comparison(self, MockAssetProducer):
+        """ Test wait_until uses the comparison function for the initial value. """
+
+        asset = ValidAsset("test_uuid", ksqlClient=MagicMock())
+
+        asset.ofa_attributes["temperature"] = AssetAttribute(
+            id="temperature",
+            value=50,
+            type="Samples",
+            tag="Temperature",
+        )
+
+        self.assertTrue(asset.wait_until(attribute_id="temperature", value=42, comparison=gt))
 
     def test_wait_until_matches_nats_message(self, MockAssetProducer):
-        """ Test wait_until returns True when a NATS message matches the desired attribute/value """
-
+        """ Test wait_until returns when a matching NATS message updates the cache. """
         asset = ValidAsset("uuid-123", ksqlClient=MagicMock())
-        attribute_id = "test_attribute"
-        expected_value = 42
 
-        # Mock __getattr__ to return an initially non-matching asset attribute
-        mock_attribute = AssetAttribute(
-            id=attribute_id,
+        attribute = AssetAttribute(
+            id="test_attribute",
             value="not_expected_value",
             type="Samples",
             tag="TestAttribute",
         )
-        asset.__getattr__ = MagicMock(return_value=mock_attribute)
+        asset.ofa_attributes["test_attribute"] = attribute
 
-        # Patch the NATS consumer start/stop
-        with patch.object(asset, "_BaseAsset__start_nats_consumer") as mock_start, \
-             patch.object(asset, "_BaseAsset__stop_subscription") as mock_stop:
+        result = None
 
-            def fake_start(subject, callback, sub_key):
-                # Simulate a NATS message with the expected value
-                callback(f"{asset.asset_uuid.upper()}.{attribute_id}", {"type": "Samples", "value": expected_value})
+        def waiter():
+            nonlocal result
+            result = asset.wait_until(attribute_id="test_attribute", value=42, timeout=1)
 
-            mock_start.side_effect = fake_start
+        thread = threading.Thread(target=waiter)
+        thread.start()
 
-            result = asset.wait_until(attribute_id=attribute_id, value=expected_value, timeout=1)
+        # simulate arrival of a NATS message
+        asset._on_message(
+            f"{asset.asset_uuid.upper()}.test_attribute",
+            {
+                "TYPE": "Samples",
+                "VALUE": 42,
+                "TAG": "TestAttribute",
+                "attributes": {
+                    "timestamp": "MockedTimeStamp"
+                }
+            }
+        )
 
-            # Assertions
-            assert result is True
-            asset.__getattr__.assert_called_with(attribute_id)
-            mock_start.assert_called_once()
-            mock_stop.assert_called_once()
+        thread.join()
 
-    def test_wait_until_times_out_nats(self, MockAssetProducer):
-        """ Test wait_until returns False on timeout when no NATS message matches """
+        self.assertTrue(result)
+        self.assertEqual(asset.ofa_attributes["test_attribute"].value, 42)
+
+    def test_wait_until_matches_comparison_after_nats_update(self, MockAssetProducer):
+        """ Test wait_until wakes up when the comparison becomes true. """
 
         asset = ValidAsset("uuid-123", ksqlClient=MagicMock())
-        attribute_id = "temperature"
-        expected_value = 42.0
 
-        # Mock __getattr__ to return an initially non-matching asset attribute
-        mock_attribute = AssetAttribute(
-            id=attribute_id,
+        asset.ofa_attributes["temperature"] = AssetAttribute(
+            id="temperature",
+            value=20,
+            type="Samples",
+            tag="Temperature",
+        )
+
+        result = None
+
+        def waiter():
+            nonlocal result
+            result = asset.wait_until(
+                attribute_id="temperature",
+                value=42,
+                comparison=gt,
+                timeout=1,
+            )
+
+        thread = threading.Thread(target=waiter)
+        thread.start()
+
+        asset._on_message(
+            f"{asset.asset_uuid.upper()}.temperature",
+            {
+                "TYPE": "Samples",
+                "VALUE": 50,
+                "TAG": "Temperature",
+                "attributes": {"timestamp": "MockedTimeStamp"},
+            },
+        )
+
+        thread.join()
+
+        self.assertTrue(result)
+
+    def test_wait_until_times_out(self, MockAssetProducer):
+        """ Test wait_until returns False when the attribute never reaches the expected value. """
+        asset = ValidAsset("uuid-123", ksqlClient=MagicMock())
+
+        attribute = AssetAttribute(
+            id="temperature",
             value=10.0,
             type="Samples",
             tag="Temperature",
         )
-        asset.__getattr__ = MagicMock(return_value=mock_attribute)
 
-        # Patch NATS start/stop
-        with patch.object(asset, "_BaseAsset__start_nats_consumer") as mock_start, \
-             patch.object(asset, "_BaseAsset__stop_subscription") as mock_stop:
+        asset.ofa_attributes["temperature"] = attribute
 
-            # Do not call the callback, simulating no matching message
-            mock_start.side_effect = lambda subject, callback, sub_key: None
+        result = asset.wait_until(attribute_id="temperature", value=42.0, timeout=0.5)
 
-            result = asset.wait_until(attribute_id=attribute_id, value=expected_value, timeout=0.5)
+        self.assertFalse(result)
 
-            # Assertions
-            assert result is False
-            asset.__getattr__.assert_called_with(attribute_id)
-            mock_start.assert_called_once()
-            mock_stop.assert_called_once()
+        # Value should remain unchanged
+        self.assertEqual(asset.ofa_attributes["temperature"].value, 10.0)
 
     def test_wait_until_ksqldb_matches(self, MockAssetProducer):
-        """ Test wait_until with use_ksqlDB=True returns True when ksqlDB eventually matches """
-        asset = ValidAsset("test_uuid", ksqlClient=MagicMock())
+        """ Test wait_until with use_ksqlDB=True returns True when ksqlDB eventually matches. """
 
-        initial_attribute = AssetAttribute(
+        ksql = MagicMock()
+
+        def query_side_effect(query):
+            # Constructor queries
+            if "TYPE != 'Method'" in query:
+                return []
+
+            if "TYPE='Method'" in query:
+                return []
+
+            # wait_until polling
+            query_side_effect.calls += 1
+
+            if query_side_effect.calls == 1:
+                return [{
+                    "VALUE": "initial",
+                    "TYPE": "Events",
+                    "TIMESTAMP": "MockedTimeStamp",
+                }]
+
+            return [{
+                "VALUE": "target",
+                "TYPE": "Events",
+                "TIMESTAMP": "MockedTimeStamp",
+            }]
+
+        query_side_effect.calls = 0
+        ksql.query.side_effect = query_side_effect
+
+        asset = ValidAsset("test_uuid", ksqlClient=ksql)
+
+        asset.ofa_attributes["test_attribute"] = AssetAttribute(
             id="test_attribute",
             value="initial",
             type="Events",
             tag="TestAttribute",
             timestamp="MockedTimeStamp",
-        )
-        matching_attribute = AssetAttribute(
-            id="test_attribute",
-            value="target",
-            type="Events",
-            tag="TestAttribute",
-            timestamp="MockedTimeStamp",
-        )
-
-        asset.__getattr__ = MagicMock(
-            side_effect=[initial_attribute, matching_attribute]
-        )
-
-        result = asset.wait_until(attribute_id="test_attribute", value="target", timeout=10, use_ksqlDB=True)
-
-        self.assertTrue(result)
-        self.assertEqual(asset.__getattr__.call_count, 2)
-
-    def test_wait_until_ksqldb_waits_until_timestamp_available(self, MockAssetProducer):
-        """ Test wait_until waits until the matching attribute is available in ksqlDB """
-        asset = ValidAsset("test_uuid", ksqlClient=MagicMock())
-
-        unavailable_attribute = AssetAttribute(
-            id="test_attribute",
-            value="target",
-            type="Events",
-            tag="TestAttribute",
-            timestamp="UNAVAILABLE",
-        )
-        available_attribute = AssetAttribute(
-            id="test_attribute",
-            value="target",
-            type="Events",
-            tag="TestAttribute",
-            timestamp="MockedTimeStamp",
-        )
-
-        asset.__getattr__ = MagicMock(
-            side_effect=[unavailable_attribute, available_attribute]
         )
 
         result = asset.wait_until(
@@ -946,221 +1404,323 @@ class TestBaseAsset(TestCase):
         )
 
         self.assertTrue(result)
-        self.assertEqual(asset.__getattr__.call_count, 2)
+        self.assertEqual(query_side_effect.calls, 2)
 
     def test_wait_until_ksqldb_timeout(self, MockAssetProducer):
-        """ Test wait_until with use_ksqlDB=True returns False after timeout when no match is found """
-        asset = ValidAsset("test_uuid", ksqlClient=MagicMock())
-        mock_attribute = AssetAttribute(
+        """ Test wait_until with use_ksqlDB=True returns False after timeout when no match is found. """
+
+        ksql = MagicMock()
+
+        def query_side_effect(query):
+            # Constructor queries
+            if "TYPE != 'Method'" in query:
+                return []
+
+            if "TYPE='Method'" in query:
+                return []
+
+            # wait_until polling always returns the same value
+            query_side_effect.calls += 1
+            return [{
+                "VALUE": "initial",
+                "TYPE": "Events",
+                "TIMESTAMP": "MockedTimeStamp",
+            }]
+
+        query_side_effect.calls = 0
+        ksql.query.side_effect = query_side_effect
+
+        asset = ValidAsset("test_uuid", ksqlClient=ksql)
+
+        asset.ofa_attributes["test_attribute"] = AssetAttribute(
             id="test_attribute",
             value="initial",
             type="Events",
             tag="TestAttribute",
+            timestamp="MockedTimeStamp",
         )
-        asset.__getattr__ = MagicMock(return_value=mock_attribute)
 
-        # Test timeout when use_ksqlDB is True
-        result = asset.wait_until(attribute_id="test_attribute", value="target", timeout=1, use_ksqlDB=True)
+        result = asset.wait_until(
+            attribute_id="test_attribute",
+            value="target",
+            timeout=1,
+            use_ksqlDB=True,
+        )
+
         self.assertFalse(result)
+        self.assertGreater(query_side_effect.calls, 1)
 
-    def test___start_nats_consumer_starts_and_registers_subscriber(self, MockAssetProducer):
-        """ Test that `__start_nats_consumer` creates, starts, and registers a NATSSubscriber """
+    def test___start_nats_consumer(self, MockAssetProducer):
+        """ Test that __start_nats_consumer creates and starts the asset subscriber. """
         asset = ValidAsset("uuid-123", ksqlClient=MagicMock())
+
         mock_loop = MagicMock()
-        object.__setattr__(asset, "loop_thread", mock_loop)  # avoid recursion in __setattr__
-        callback = MagicMock()
-        sub_key = "test_sub"
+        object.__setattr__(asset, "loop_thread", mock_loop)
 
         with patch("openfactory.assets.asset_base.NATSSubscriber") as MockSubscriber, \
-             patch("openfactory.assets.asset_base.get_nats_cluster_url", return_value="nats://mocked_cluster"):
+            patch("openfactory.assets.asset_base.get_nats_cluster_url",
+                  return_value="nats://mocked_cluster"):
 
-            mock_sub_instance = MockSubscriber.return_value
+            mock_subscriber = MockSubscriber.return_value
 
-            # Call the private method
-            asset._BaseAsset__start_nats_consumer("subject.test", callback, sub_key=sub_key)
+            asset._BaseAsset__start_nats_consumer()
 
-            # Ensure NATSSubscriber initialized with correct args
-            MockSubscriber.assert_called_once_with(mock_loop, "nats://mocked_cluster", "subject.test", callback)
-            # Ensure subscriber start() is called
-            mock_sub_instance.start.assert_called_once()
-            # Ensure subscriber stored in self.subscribers
-            assert asset.subscribers[sub_key] == mock_sub_instance
-
-    def test___stop_subscription_stops_and_removes_subscriber(self, MockAssetProducer):
-        """ Test that `__stop_subscription` stops and removes a NATSSubscriber """
-        asset = ValidAsset("uuid-123", ksqlClient=MagicMock())
-        mock_sub = MagicMock()
-        asset.subscribers["test_sub"] = mock_sub
-
-        # Call the private method
-        asset._BaseAsset__stop_subscription("test_sub")
-
-        # Ensure stop() is called
-        mock_sub.stop.assert_called_once()
-        # Ensure subscriber removed from self.subscribers
-        assert "test_sub" not in asset.subscribers
-
-    def test___stop_subscription_with_nonexistent_key_does_nothing(self, MockAssetProducer):
-        """ Test that `__stop_subscription` gracefully handles a missing subscriber key """
-        asset = ValidAsset("uuid-123", ksqlClient=MagicMock())
-        # No subscriber registered
-        asset._BaseAsset__stop_subscription("nonexistent_key")
-        # Should not raise and self.subscribers remains empty
-        assert asset.subscribers == {}
-
-    def test_subscribe_to_attribute_starts_nats_consumer(self, MockAssetProducer):
-        """ Test that `subscribe_to_attribute` starts a NATS consumer correctly """
-        asset = ValidAsset("uuid-123", ksqlClient=MagicMock())
-        callback = MagicMock()
-
-        with patch.object(asset, "_BaseAsset__start_nats_consumer") as mock_start:
-            asset.subscribe_to_attribute('mock_id', callback)
-            mock_start.assert_called_once_with(
-                f"{asset.asset_uuid.upper()}.mock_id",
-                callback,
-                sub_key="subscribe_to_attribute_mock_id"
+            MockSubscriber.assert_called_once_with(
+                mock_loop,
+                "nats://mocked_cluster",
+                "UUID-123.*",
+                asset._on_message,
             )
 
-    def test_stop_attribute_subscription_stops_nats_consumer(self, MockAssetProducer):
-        """ Test that `stop_attribute_subscription` stops the NATS consumer correctly """
-        asset = ValidAsset("uuid-123", ksqlClient=MagicMock())
+            mock_subscriber.start.assert_called_once()
 
-        with patch.object(asset, "_BaseAsset__stop_subscription") as mock_stop:
-            asset.stop_attribute_subscription('mock_id')
-            mock_stop.assert_called_once_with("subscribe_to_attribute_mock_id")
+            self.assertIs(asset._subscriber, mock_subscriber)
 
-    def test_subscribe_to_messages_starts_nats_consumer(self, MockAssetProducer):
-        """ Test that `subscribe_to_messages` starts a NATS consumer correctly """
+    def test_subscribe_to_attribute_registers_callback(self, MockAssetProducer):
+        """ Test subscribe_to_attribute registers the callback. """
         asset = ValidAsset("uuid-123", ksqlClient=MagicMock())
         callback = MagicMock()
 
-        with patch.object(asset, "_BaseAsset__start_nats_consumer") as mock_start:
-            asset.subscribe_to_messages(callback)
-            mock_start.assert_called_once_with(
-                f"{asset.asset_uuid.upper()}.*",
-                callback,
-                sub_key="messages"
-            )
+        asset.subscribe_to_attribute("mock_id", callback)
 
-    def test_stop_messages_subscription_stops_nats_consumer(self, MockAssetProducer):
-        """ Test that `stop_messages_subscription` stops the NATS consumer correctly """
-        asset = ValidAsset("uuid-123", ksqlClient=MagicMock())
+        self.assertIs(asset._attribute_callbacks["mock_id"], callback)
 
-        with patch.object(asset, "_BaseAsset__stop_subscription") as mock_stop:
-            asset.stop_messages_subscription()
-            mock_stop.assert_called_once_with("messages")
-
-    def test_subscribe_to_samples_starts_nats_consumer(self, MockAssetProducer):
-        """ Test that `subscribe_to_samples` starts a NATS consumer and filters messages by TYPE=='Samples' """
+    def test_subscribe_to_attribute_callback_invoked(self, MockAssetProducer):
+        """ Test registered callback is invoked when a matching message arrives. """
         asset = ValidAsset("uuid-123", ksqlClient=MagicMock())
         callback = MagicMock()
 
-        with patch.object(asset, "_BaseAsset__start_nats_consumer") as mock_start:
-            asset.subscribe_to_samples(callback)
+        asset.subscribe_to_attribute("temperature", callback)
 
-            # Check correct subject and sub_key
-            subject_arg = f"{asset.asset_uuid.upper()}.*"
-            mock_start.assert_called_once()
-            args, kwargs = mock_start.call_args
-            assert args[0] == subject_arg
-            assert kwargs['sub_key'] == "samples"
+        asset._on_message(
+            f"{asset.asset_uuid.upper()}.temperature",
+            {
+                "TYPE": "Samples",
+                "VALUE": 42,
+                "TAG": "Temperature",
+                "attributes": {"timestamp": "MockedTimeStamp"},
+            },
+        )
 
-            # Extract the filter and test filtering
-            filter = args[1]
+        callback.assert_called_once()
 
-            # Should call callback for TYPE == 'Samples'
-            sample_msg = {"tYpe": "SampleS", "VALUE": 123}
-            filter("subject.test", sample_msg)
-            callback.assert_called_once_with("subject.test", sample_msg)
-
-            # Should NOT call callback for other types
-            callback.reset_mock()
-            other_msg = {"TYPE": "Events", "VALUE": 456}
-            filter("subject.test", other_msg)
-            callback.assert_not_called()
-
-    def test_stop_samples_subscription_stops_nats_consumer(self, MockAssetProducer):
-        """ Test that `stop_samples_subscription` stops the NATS consumer correctly """
-        asset = ValidAsset("uuid-123", ksqlClient=MagicMock())
-
-        with patch.object(asset, "_BaseAsset__stop_subscription") as mock_stop:
-            asset.stop_samples_subscription()
-            mock_stop.assert_called_once_with("samples")
-
-    def test_subscribe_to_events_starts_nats_consumer(self, MockAssetProducer):
-        """ Test that `subscribe_to_events` starts a NATS consumer and filters messages by TYPE=='Events' """
+    def test_stop_attribute_subscription_removes_callback(self, MockAssetProducer):
+        """ Test stop_attribute_subscription unregisters the callback. """
         asset = ValidAsset("uuid-123", ksqlClient=MagicMock())
         callback = MagicMock()
 
-        with patch.object(asset, "_BaseAsset__start_nats_consumer") as mock_start:
-            asset.subscribe_to_events(callback)
+        asset.subscribe_to_attribute("mock_id", callback)
 
-            # Check correct subject and sub_key
-            subject_arg = f"{asset.asset_uuid.upper()}.*"
-            mock_start.assert_called_once()
-            args, kwargs = mock_start.call_args
-            assert args[0] == subject_arg
-            assert kwargs['sub_key'] == "events"
+        self.assertIn("mock_id", asset._attribute_callbacks)
 
-            # Extract the filter and test filtering
-            filter_fn = args[1]
+        asset.stop_attribute_subscription("mock_id")
 
-            # Should call callback for TYPE == 'Events'
-            event_msg = {"TYpe": "EvEnts", "VALUE": 123}
-            filter_fn("subject.test", event_msg)
-            callback.assert_called_once_with("subject.test", event_msg)
+        self.assertNotIn("mock_id", asset._attribute_callbacks)
 
-            # Should NOT call callback for other types
-            callback.reset_mock()
-            other_msg = {"TYPE": "Samples", "VALUE": 456}
-            filter_fn("subject.test", other_msg)
-            callback.assert_not_called()
-
-    def test_stop_events_subscription_stops_nats_consumer(self, MockAssetProducer):
-        """ Test that `stop_events_subscription` stops the NATS consumer """
+    def test_stop_attribute_subscription_unknown_id(self, MockAssetProducer):
+        """ Test stopping an unknown attribute subscription does nothing. """
         asset = ValidAsset("uuid-123", ksqlClient=MagicMock())
-        mock_subscriber = MagicMock()
-        asset.subscribers["events"] = mock_subscriber
+        asset.stop_attribute_subscription("does_not_exist")
+        self.assertEqual(asset._attribute_callbacks, {})
+
+    def test_subscribe_to_messages_registers_callback(self, MockAssetProducer):
+        """ Test subscribe_to_messages registers the callback. """
+        asset = ValidAsset("uuid-123", ksqlClient=MagicMock())
+        callback = MagicMock()
+
+        asset.subscribe_to_messages(callback)
+
+        self.assertIs(asset._messages_callback, callback)
+
+    def test_subscribe_to_messages_callback_invoked(self, MockAssetProducer):
+        """ Test registered callback is invoked when a matching message arrives. """
+        asset = ValidAsset("uuid-123", ksqlClient=MagicMock())
+        callback = MagicMock()
+
+        asset.subscribe_to_messages(callback)
+
+        asset._on_message(
+            f"{asset.asset_uuid.upper()}.temperature",
+            {
+                "TYPE": "Samples",
+                "VALUE": 42,
+                "TAG": "Temperature",
+                "attributes": {"timestamp": "MockedTimeStamp"},
+            },
+        )
+
+        callback.assert_called_once()
+
+    def test_stop_messages_subscription_removes_callback(self, MockAssetProducer):
+        """ Test stop_messages_subscription unregisters the callback. """
+        asset = ValidAsset("uuid-123", ksqlClient=MagicMock())
+        callback = MagicMock()
+
+        asset.subscribe_to_messages(callback)
+        self.assertIs(asset._messages_callback, callback)
+
+        asset.stop_messages_subscription()
+
+        self.assertIsNone(asset._messages_callback)
+
+    def test_subscribe_to_samples_registers_callback(self, MockAssetProducer):
+        """ Test subscribe_to_samples registers the callback. """
+        asset = ValidAsset("uuid-123", ksqlClient=MagicMock())
+        callback = MagicMock()
+
+        asset.subscribe_to_samples(callback)
+
+        self.assertIs(asset._samples_callback, callback)
+
+    def test_subscribe_to_samples_callback_invoked(self, MockAssetProducer):
+        """ Test registered callback is invoked only for sample messages. """
+        asset = ValidAsset("uuid-123", ksqlClient=MagicMock())
+        callback = MagicMock()
+
+        asset.subscribe_to_samples(callback)
+
+        # Sample message -> callback should be invoked
+        sample_msg = {
+            "TYPE": "Samples",
+            "VALUE": 42,
+            "TAG": "Temperature",
+            "attributes": {"timestamp": "MockedTimeStamp"},
+        }
+
+        asset._on_message(f"{asset.asset_uuid.upper()}.temperature", sample_msg)
+
+        callback.assert_called_once_with(f"{asset.asset_uuid.upper()}.temperature", sample_msg)
+
+        callback.reset_mock()
+
+        # Event message -> callback should NOT be invoked
+        event_msg = {
+            "TYPE": "Events",
+            "VALUE": 123,
+            "TAG": "Execution",
+            "attributes": {"timestamp": "MockedTimeStamp"},
+        }
+
+        asset._on_message(f"{asset.asset_uuid.upper()}.execution", event_msg)
+
+        callback.assert_not_called()
+
+    def test_stop_samples_subscription_removes_callback(self, MockAssetProducer):
+        """ Test stop_samples_subscription unregisters the callback. """
+        asset = ValidAsset("uuid-123", ksqlClient=MagicMock())
+        callback = MagicMock()
+
+        asset.subscribe_to_samples(callback)
+        self.assertIs(asset._samples_callback, callback)
+
+        asset.stop_samples_subscription()
+
+        self.assertIsNone(asset._samples_callback)
+
+    def test_subscribe_to_events_registers_callback(self, MockAssetProducer):
+        """ Test subscribe_to_events registers the callback. """
+        asset = ValidAsset("uuid-123", ksqlClient=MagicMock())
+        callback = MagicMock()
+
+        asset.subscribe_to_events(callback)
+
+        self.assertIs(asset._events_callback, callback)
+
+    def test_subscribe_to_events_callback_invoked(self, MockAssetProducer):
+        """ Test registered callback is invoked only for event messages. """
+        asset = ValidAsset("uuid-123", ksqlClient=MagicMock())
+        callback = MagicMock()
+
+        asset.subscribe_to_events(callback)
+
+        # Event message -> callback should be invoked
+        event_msg = {
+            "TYPE": "Events",
+            "VALUE": 123,
+            "TAG": "Execution",
+            "attributes": {"timestamp": "MockedTimeStamp"},
+        }
+
+        asset._on_message(f"{asset.asset_uuid.upper()}.execution", event_msg)
+
+        callback.assert_called_once_with(f"{asset.asset_uuid.upper()}.execution", event_msg)
+
+        callback.reset_mock()
+
+        # Sample message -> callback should NOT be invoked
+        sample_msg = {
+            "TYPE": "Samples",
+            "VALUE": 42,
+            "TAG": "Temperature",
+            "attributes": {"timestamp": "MockedTimeStamp"},
+        }
+
+        asset._on_message(f"{asset.asset_uuid.upper()}.temperature", sample_msg)
+
+        callback.assert_not_called()
+
+    def test_stop_events_subscription_removes_callback(self, MockAssetProducer):
+        """ Test stop_events_subscription unregisters the callback. """
+        asset = ValidAsset("uuid-123", ksqlClient=MagicMock())
+        callback = MagicMock()
+
+        asset.subscribe_to_events(callback)
+        self.assertIs(asset._events_callback, callback)
 
         asset.stop_events_subscription()
-        mock_subscriber.stop.assert_called_once()
-        assert "events" not in asset.subscribers
 
-    def test_subscribe_to_conditions_starts_nats_consumer(self, MockAssetProducer):
-        """ Test that `subscribe_to_conditions` starts a NATS consumer and filters messages by TYPE=='Condition' """
+        self.assertIsNone(asset._events_callback)
+
+    def test_subscribe_to_conditions_registers_callback(self, MockAssetProducer):
+        """ Test subscribe_to_conditions registers the callback. """
         asset = ValidAsset("uuid-123", ksqlClient=MagicMock())
         callback = MagicMock()
 
-        with patch.object(asset, "_BaseAsset__start_nats_consumer") as mock_start:
-            asset.subscribe_to_conditions(callback)
+        asset.subscribe_to_conditions(callback)
 
-            # Check correct subject and sub_key
-            subject_arg = f"{asset.asset_uuid.upper()}.*"
-            mock_start.assert_called_once()
-            args, kwargs = mock_start.call_args
-            assert args[0] == subject_arg
-            assert kwargs['sub_key'] == "conditions"
+        self.assertIs(asset._conditions_callback, callback)
 
-            # Extract the filter and test filtering
-            filter_fn = args[1]
-
-            # Should call callback for TYPE == 'Condition'
-            condition_msg = {"tyPE": "CondiTion", "VALUE": 123}
-            filter_fn("subject.test", condition_msg)
-            callback.assert_called_once_with("subject.test", condition_msg)
-
-            # Should NOT call callback for other types
-            callback.reset_mock()
-            other_msg = {"TYPE": "Samples", "VALUE": 456}
-            filter_fn("subject.test", other_msg)
-            callback.assert_not_called()
-
-    def test_stop_conditions_subscription_stops_nats_consumer(self, MockAssetProducer):
-        """ Test that `stop_conditions_subscription` stops the NATS consumer """
+    def test_subscribe_to_conditions_callback_invoked(self, MockAssetProducer):
+        """ Test registered callback is invoked only for condition messages. """
         asset = ValidAsset("uuid-123", ksqlClient=MagicMock())
-        mock_subscriber = MagicMock()
-        asset.subscribers["conditions"] = mock_subscriber
+        callback = MagicMock()
+
+        asset.subscribe_to_conditions(callback)
+
+        # Condition message -> callback should be invoked
+        condition_msg = {
+            "TYPE": "Condition",
+            "VALUE": 123,
+            "TAG": "Execution",
+            "attributes": {"timestamp": "MockedTimeStamp"},
+        }
+
+        asset._on_message(f"{asset.asset_uuid.upper()}.execution", condition_msg)
+
+        callback.assert_called_once_with(f"{asset.asset_uuid.upper()}.execution", condition_msg)
+
+        callback.reset_mock()
+
+        # Sample message -> callback should NOT be invoked
+        sample_msg = {
+            "TYPE": "Samples",
+            "VALUE": 42,
+            "TAG": "Temperature",
+            "attributes": {"timestamp": "MockedTimeStamp"},
+        }
+
+        asset._on_message(f"{asset.asset_uuid.upper()}.temperature", sample_msg)
+
+        callback.assert_not_called()
+
+    def test_stop_conditions_subscription_removes_callback(self, MockAssetProducer):
+        """ Test stop_conditions_subscription unregisters the callback. """
+        asset = ValidAsset("uuid-123", ksqlClient=MagicMock())
+        callback = MagicMock()
+
+        asset.subscribe_to_conditions(callback)
+        self.assertIs(asset._conditions_callback, callback)
 
         asset.stop_conditions_subscription()
-        mock_subscriber.stop.assert_called_once()
-        assert "conditions" not in asset.subscribers
+
+        self.assertIsNone(asset._conditions_callback)

--- a/tests/openfactory/assets/test_baseasset_test_mode.py
+++ b/tests/openfactory/assets/test_baseasset_test_mode.py
@@ -41,16 +41,17 @@ class TestBaseAssetTestMode(TestCase):
         self.assertEqual(asset.bar, "hello")
 
     def test_add_attribute(self):
-        """ Test that add_attributes populates internal list in test_mode """
+        """ Test add_attribute stores the attribute. """
         asset = ValidAsset("uuid-test", self.ksql_mock, test_mode=True)
 
-        # Add two AssetAttributes
-        attribute1 = AssetAttribute(id='test_attribute1', value='attr1', type='Events', tag='test')
-        attribute2 = AssetAttribute(id='test_attribute2', value='attr1', type='Events', tag='test')
+        attribute1 = AssetAttribute(id="test_attribute1", value="attr1", type="Events", tag="test")
+        attribute2 = AssetAttribute(id="test_attribute2", value="attr2", type="Events", tag="test")
+
         asset.add_attribute(attribute1)
         asset.add_attribute(attribute2)
 
-        self.assertEqual(asset._mocked_attributes, [attribute1, attribute2])
+        self.assertEqual(asset.test_attribute1.value, "attr1")
+        self.assertEqual(asset.test_attribute2.value, "attr2")
 
     def test_attributes(self):
         """ Test attributes() """
@@ -96,18 +97,6 @@ class TestBaseAssetTestMode(TestCase):
         asset.add_attribute(attr)
 
         self.assertEqual(asset.events(), [{'ID': 'attribute', 'VALUE': 'some_value', 'TAG': 'test'}])
-
-    def test_get_mocked_attribute_by_id(self):
-        """ Test __get_mocked_attribute_by_id """
-        asset = ValidAsset("uuid-test", self.ksql_mock, test_mode=True)
-
-        # Add an AssetAttribute
-        attr = AssetAttribute(id='attribute1', value='attr1', type='Events', tag='test')
-        asset.add_attribute(attr)
-        self.assertEqual(asset._get_mocked_attribute_by_id('attribute1'), attr)
-
-        # A none existing AssetAttribute should return None
-        self.assertEqual(asset._get_mocked_attribute_by_id('does_not_exist'), None)
 
     def test_setattr_in_test_mode_bypasses_producer(self):
         """ Test AssetAttribute attributes """


### PR DESCRIPTION
## Introduce a stateful BaseAsset synchronized by NATS

This PR implements the new stateful architecture for `BaseAsset`.

Instead of acting as a thin proxy that repeatedly queries ksqlDB, `BaseAsset` now maintains a live in-memory representation of an OpenFactory asset. During initialization, the current asset state is loaded from ksqlDB and stored in internal attribute and method caches. A permanent NATS subscription then keeps this state synchronized with the OpenFactory event stream throughout the lifetime of the object.

Attribute access, collection methods (`attributes()`, `samples()`, `events()`, `conditions()`, and `methods()`), and callback dispatching now operate directly on this synchronized internal state. The `wait_until()` implementation has also been redesigned to wait on the local state using a condition variable while preserving the existing `use_ksqlDB=True` option for waiting on the distributed state materialized by the OpenFactory stream-processing pipeline.

This architectural change significantly reduces ksqlDB queries, eliminates temporary NATS subscriptions, centralizes callback dispatching, and allows `BaseAsset` to behave as a live representation of an OpenFactory asset rather than a stateless proxy.

This PR also updates the classes deriving from `BaseAsset` to use the new stateful architecture.
