### PR TITLE
Fix invalid command sent during OpenFactory method registration

### DIFF
--- a/openfactory/apps/ofaapp.py
+++ b/openfactory/apps/ofaapp.py
@@ -234,14 +234,6 @@ class OpenFactoryApp(Asset, metaclass=OpenFactoryAppMeta):
 
                     # Register command as asset attributes
                     self._register_ofa_method(method)
-                    self.add_attribute(
-                        asset_attribute=AssetAttribute(
-                            id=cmd_attribute,
-                            value="",
-                            type='OpenFactory',
-                            tag='Method.Command'
-                        )
-                    )
 
                     if not self._test_mode:
                         self.subscribe_to_attribute(cmd_attribute, make_callback(method))

--- a/openfactory/assets/asset_base.py
+++ b/openfactory/assets/asset_base.py
@@ -497,7 +497,18 @@ class BaseAsset:
         )
 
         # Set the attribute to trigger the command
-        self.__setattr__(f"{method}_CMD", envelope.model_dump_json())
+        cmd_id = f"{method}_CMD"
+        if cmd_id not in self.ofa_attributes:
+            self.add_attribute(
+                asset_attribute=AssetAttribute(
+                    id=cmd_id,
+                    value=envelope.model_dump_json(),
+                    type='OpenFactory',
+                    tag='Method.Command'
+                )
+            )
+        else:
+            self.__setattr__(cmd_id, envelope.model_dump_json())
 
         return str(correlation_id)
 
@@ -570,7 +581,7 @@ class BaseAsset:
         - If the value is a raw value (e.g., int, str, etc.), it wraps the value in an
         `AssetAttribute` using the current attribute’s metadata (tag, type) and sends it.
 
-        **Notes**:
+        Notes:
             If a new class attribute has to be defined in the constructor of the child class, one has to use
             ```python
             object.__setattr__(self, 'new_class_attribute', <some value>)

--- a/tests/openfactory/apps/test_openfactoryapp_methods.py
+++ b/tests/openfactory/apps/test_openfactoryapp_methods.py
@@ -257,31 +257,6 @@ class TestOpenFactoryAppMethods(unittest.TestCase):
 
         self.assertIn("Failed to convert argument 'x'", str(ctx.exception))
 
-    def test_cmd_attribute_created(self):
-        """ Verify CMD attribute is added for decorated methods. """
-
-        class MyApp(OpenFactoryApp):
-
-            @ofa_method()
-            def move_axis(self, x: float, y: float):
-                return x + y
-
-        MyApp(
-            bootstrap_servers='mock_bootstrap',
-            ksqlClient=self.ksql_mock,
-            asset_router_url='mocked_asset_url'
-        )
-
-        calls = self.mock_add_attribute.call_args_list
-
-        cmd_found = False
-        for c in calls:
-            attr = c.kwargs["asset_attribute"]
-            if attr.id == "move_axis_CMD":
-                cmd_found = True
-
-        self.assertTrue(cmd_found)
-
     def test_register_ofa_method_creates_contract(self):
         """ Verify that method contract is correctly generated. """
 

--- a/tests/openfactory/apps/test_openfactoryapp_test_mode.py
+++ b/tests/openfactory/apps/test_openfactoryapp_test_mode.py
@@ -1,3 +1,4 @@
+import json
 from unittest import TestCase
 from unittest.mock import Mock
 from openfactory.kafka import KSQLDBClient
@@ -50,8 +51,11 @@ class TestOpenFactoryAppTestMode(TestCase):
         self.assertEqual(self.app.status.tag, 'App.Status')
 
     def test_ofa_methods_attributes(self):
-        """ Test ofa_methods command attributes """
-        self.assertEqual(self.app.stop_axis_CMD.value, '')
+        """ Test ofa methods command attributes """
+        correlation_id = self.app.method('stop_axis', sender_uuid='test', args=[])
+        cmd_value = json.loads(self.app.stop_axis_CMD.value)
+        self.assertEqual(cmd_value['header']['sender_uuid'], 'test')
+        self.assertEqual(cmd_value['header']['correlation_id'], correlation_id)
         self.assertEqual(self.app.stop_axis_CMD.type, 'OpenFactory')
         self.assertEqual(self.app.stop_axis_CMD.tag, 'Method.Command')
 

--- a/tests/openfactory/assets/test_baseasset.py
+++ b/tests/openfactory/assets/test_baseasset.py
@@ -708,31 +708,28 @@ class TestBaseAsset(TestCase):
 
         asset = ValidAsset("uuid-123", ksqlClient=MagicMock())
 
-        # Spy on __setattr__
-        asset.__setattr__ = MagicMock()
+        # Spy on send_asset_attribute
+        asset.producer.send_asset_attribute = MagicMock()
 
         correlation_id = asset.method(
-            method="start",
-            sender_uuid="SENDER-1",
-            args=[("param1", "value1"), ("param2", "value2")]
-        )
+                    method="start",
+                    sender_uuid="SENDER-1",
+                    args=[("param1", "value1"), ("param2", "value2")]
+                )
 
-        # Ensure attribute was set correctly
-        asset.__setattr__.assert_called_once()
+        asset.producer.send_asset_attribute.assert_called_once()
 
-        attr_name, payload = asset.__setattr__.call_args.args
+        # Get arguments of send_asset_attribute
+        asset_uuid, asset_attribute = asset.producer.send_asset_attribute.call_args.args
+        cmd_headder = json.loads(asset_attribute.value)["header"]
+        cmd_args = json.loads(asset_attribute.value)["arguments"]
 
-        assert attr_name == "start_CMD"
-
-        # Parse payload
-        parsed = json.loads(payload)
-
-        assert parsed["header"]["correlation_id"] == correlation_id
-        assert parsed["header"]["sender_uuid"] == "SENDER-1"
-        assert parsed["arguments"] == {
-            "param1": "value1",
-            "param2": "value2"
-        }
+        # Ensure send_asset_attribute was called correctly
+        self.assertEqual(asset_uuid, "uuid-123")
+        self.assertEqual(asset_attribute.id, "start_CMD")
+        self.assertEqual(cmd_headder["correlation_id"], correlation_id)
+        self.assertEqual(cmd_headder["sender_uuid"], "SENDER-1")
+        self.assertEqual(cmd_args, {"param1": "value1", "param2": "value2"})
 
     def test_setattr_non_asset_attribute(self, MockAssetProducer):
         """ Test setting a non-asset attribute (not in attributes list) """


### PR DESCRIPTION
# Fix invalid command sent during OpenFactory method registration

## Summary

Fix an issue where OpenFactory applications send an empty command while registering OpenFactory methods during startup.

Previously, when methods were discovered from ksqlDB, `_subscribe_ofa_methods()` called `add_attribute()`. Since no command had been received yet, this resulted in an empty payload being processed, producing validation errors such as:

```text
[DEMO-APP] (2026-07-28 14:19:21) ERROR [DEMO-APP] Failed to execute move_axis: ValidationError: 1 validation error for CommandEnvelope
  Invalid JSON: EOF while parsing a value at line 1 column 0 [type=json_invalid, input_value='', input_type=str]
```

## Root Cause

`_subscribe_ofa_methods()` eagerly initialized method attributes by calling `add_attribute()`. This caused the attribute callback to be invoked before any valid command had been published, resulting in an attempt to deserialize an empty payload.

## Changes

* Remove the call to `add_attribute()` from `_subscribe_ofa_methods()`.
* Lazily register the attribute from `method()` the first time an OpenFactory method execution is requested.
* Ensure `add_attribute()` is invoked only once per method.

## Result

Method registration no longer triggers the processing of an empty command during application startup. OpenFactory methods are registered on first use, eliminating the startup validation error while preserving the existing method execution behavior.
