### PR TITLE
Add BaseAsset.resync_state() to force a full state resynchronization

### DIFF
--- a/openfactory/assets/asset_base.py
+++ b/openfactory/assets/asset_base.py
@@ -166,6 +166,24 @@ class BaseAsset:
         self.__start_nats_consumer()
 
         # Retrieve current state from ksqlDB
+        self.resync_state()
+
+    def resync_state(self) -> None:
+        """
+        Resynchronizes the local asset state with the distributed state stored in ksqlDB.
+
+        This method reloads all asset attributes and methods from ksqlDB and updates
+        the local cache accordingly. Existing entries are overwritten with the latest
+        values, while newly discovered attributes and methods are added. Existing
+        entries that are not present in the retrieved state are left unchanged.
+
+        This method is useful for recovering from missed updates or forcing the local
+        cache to resynchronize with the distributed asset state.
+
+        Note:
+            This method does not restart the NATS subscription. It only refreshes
+            the local cache from the current state materialized in ksqlDB.
+        """
         self._fetch_attributes()
         self._fetch_methods()
 

--- a/tests/openfactory/assets/test_baseasset.py
+++ b/tests/openfactory/assets/test_baseasset.py
@@ -177,6 +177,19 @@ class TestBaseAsset(TestCase):
         with self.assertRaises(TypeError):
             InvalidConsumer('some_id', self.ksql_mock)
 
+    def test_resync_state_refreshes_attributes_and_methods(self, MockAssetProducer):
+        """ Test resync_state() reloads attributes and methods from ksqlDB. """
+
+        asset = ValidAsset("uuid-123", ksqlClient=MagicMock())
+
+        asset._fetch_attributes = MagicMock()
+        asset._fetch_methods = MagicMock()
+
+        asset.resync_state()
+
+        asset._fetch_attributes.assert_called_once_with()
+        asset._fetch_methods.assert_called_once_with()
+
     def test_close_stops_subscriber(self, MockAssetProducer):
         """ Test close() stops the asset's NATS subscriber. """
         asset = ValidAsset("uuid-123", ksqlClient=MagicMock())


### PR DESCRIPTION
# Add `BaseAsset.resync_state()` to force a full state resynchronization

## Summary

This PR introduces a new `BaseAsset.resync_state()` method that allows applications to explicitly resynchronize an asset's local cache with the distributed state stored in ksqlDB.

## Motivation

`BaseAsset` builds its initial state by loading all asset attributes and methods from ksqlDB and then keeps this local cache synchronized through NATS updates.

While this is sufficient during normal operation, applications currently have no way to explicitly request a full resynchronization of the local cache. Such a capability is useful after recovering from temporary communication failures, for debugging, or whenever an application wants to ensure that its local cache reflects the current distributed state.

## Changes

* Added the public `BaseAsset.resync_state()` method.
* Reloads all asset attributes from ksqlDB.
* Reloads all asset methods from ksqlDB.
* Updates the existing local cache by overwriting existing entries and adding newly discovered ones.
* Does **not** restart the NATS subscription.
* Does **not** clear the local cache before reloading.

## Testing

Added unit tests verifying that `resync_state()` invokes both `_fetch_attributes()` and `_fetch_methods()`, ensuring that the public API behaves as expected and is protected against future regressions.
