### PR TITLE
Make timeout keyword-only in wait_until()

### DIFF
--- a/openfactory/assets/asset_base.py
+++ b/openfactory/assets/asset_base.py
@@ -768,7 +768,8 @@ class BaseAsset:
         """
         self._add_reference(direction="below", new_reference=below_asset_reference)
 
-    def wait_until(self, attribute_id: str, value: Any, comparison: Callable[[Any, Any], bool] = eq, timeout: int = 30, use_ksqlDB: bool = False) -> bool:
+    def wait_until(self, attribute_id: str, value: Any, comparison: Callable[[Any, Any], bool] = eq,
+                   *, timeout: int = 30, use_ksqlDB: bool = False) -> bool:
         """
         Waits until an asset attribute satisfies a comparison or times out.
 
@@ -807,6 +808,14 @@ class BaseAsset:
         Returns:
             bool: `True` if the comparison is satisfied before the timeout expires, otherwise ``False``.
         """
+        if not callable(comparison):
+            raise TypeError(
+                f"comparison must be a callable (e.g. operator.eq or operator.gt), "
+                f"got {type(comparison).__name__}. "
+                f"Did you mean to specify the timeout? "
+                f"Use wait_until(..., timeout={comparison!r})."
+            )
+
         # If not an attribute  raise
         if attribute_id not in self.ofa_attributes:
             raise OFAException(f"'{attribute_id}' is not an Attribute of Asset '{self.asset_uuid}'")

--- a/tests/openfactory/assets/test_baseasset.py
+++ b/tests/openfactory/assets/test_baseasset.py
@@ -1225,6 +1225,23 @@ class TestBaseAsset(TestCase):
         )
         asset.producer.send_asset_attribute.assert_called_once_with("asset-001", expected_attr)
 
+    def test_wait_until_invalid_comparison_raises(self, MockAssetProducer):
+        """ Test wait_until raises a helpful error when comparison is not callable. """
+        asset = ValidAsset("test_uuid", ksqlClient=MagicMock())
+
+        with self.assertRaises(TypeError) as ctx:
+            asset.wait_until("temperature", 42, 5)
+
+        self.assertIn("comparison must be a callable", str(ctx.exception))
+        self.assertIn("timeout=5", str(ctx.exception))
+
+    def test_wait_until_timeout_is_keyword_only(self, MockAssetProducer):
+        """ Test wait_until requires timeout to be passed as a keyword. """
+        asset = ValidAsset("test_uuid", ksqlClient=MagicMock())
+
+        with self.assertRaises(TypeError):
+            asset.wait_until("temperature", 42, gt, 5)
+
     def test_wait_until_method_raises(self, MockAssetProducer):
         """ wait_until cannot be used on methods. """
         asset = ValidAsset("test_uuid", ksqlClient=MagicMock())


### PR DESCRIPTION
## Make `timeout` keyword-only in `wait_until()`

## Summary

This PR improves the usability of `BaseAsset.wait_until()` by making the `timeout` parameter keyword-only and adding validation for the `comparison` argument.

Previously, it was easy to accidentally write:

```python
asset.wait_until("Temperature", 42, 5)
```

expecting `5` to represent the timeout. Instead, it was interpreted as the `comparison` callable, eventually resulting in the unhelpful error:

```
TypeError: 'int' object is not callable
```

This PR makes this misuse much easier to diagnose.

## Changes

* Make `timeout` a keyword-only argument.
* Validate that `comparison` is callable before performing any comparison.
* Raise a descriptive `TypeError` when a non-callable comparison is provided, including a suggestion to use `timeout=...`.
* Add unit tests covering:

  * invalid `comparison` arguments;
  * the keyword-only `timeout` parameter.

## Example

Before:

```python
asset.wait_until("Temperature", 42, 5)
```

```
TypeError: 'int' object is not callable
```

After:

```python
asset.wait_until("Temperature", 42, 5)
```

```
TypeError: comparison must be a callable (e.g. operator.eq or operator.gt), got int.
Did you mean to specify the timeout? Use wait_until(..., timeout=5).
```

The preferred usage is now:

```python
asset.wait_until("Execution", "ACTIVE")
asset.wait_until("Temperature", 42, timeout=5)
asset.wait_until("Temperature", 42, gt, timeout=5)
```

## Breaking change

`timeout` is now keyword-only. Code using positional arguments such as

```python
asset.wait_until("Temperature", 42, gt, 5)
```

must be updated to

```python
asset.wait_until("Temperature", 42, gt, timeout=5)
```

This change improves the readability of the API and prevents accidental misuse.
