### PR TITLE
Always provide a default Deploy configuration

### DIFF
--- a/openfactory/schemas/apps.py
+++ b/openfactory/schemas/apps.py
@@ -353,7 +353,7 @@ class OpenFactoryAppSchema(AttachUNSMixin, BaseModel):
     )
 
     deploy: Optional[Deploy] = Field(
-        default=None,
+        default_factory=Deploy,
         description="Deployment configuration including resources and placement."
     )
 

--- a/tests/openfactory/schemas/test_apps.py
+++ b/tests/openfactory/schemas/test_apps.py
@@ -6,6 +6,7 @@ from pydantic import ValidationError
 from tempfile import NamedTemporaryFile
 from openfactory.schemas.apps import OpenFactoryAppsConfig, RoutingError, get_apps_from_config_file
 from openfactory.schemas.uns import UNSSchema
+from openfactory.schemas.common import Deploy
 
 
 class TestOpenFactoryAppsConfig(unittest.TestCase):
@@ -591,8 +592,8 @@ class TestOpenFactoryAppsConfig(unittest.TestCase):
         # Still has UNS enrichment
         self.assertEqual(app.uns["uns_id"], "OpenFactory/WC2/DEMO-APP")
 
-    def test_optional_deploy(self):
-        """ deploy field is optional """
+    def test_default_deploy(self):
+        """ A default Deploy configuration is created when omitted. """
         valid_config = {
             "apps": {
                 "demo1": {
@@ -602,7 +603,12 @@ class TestOpenFactoryAppsConfig(unittest.TestCase):
             }
         }
         config = OpenFactoryAppsConfig(**valid_config)
-        self.assertIsNone(config.apps["demo1"].deploy)
+        deploy = config.apps["demo1"].deploy
+
+        self.assertIsInstance(deploy, Deploy)
+        self.assertEqual(deploy.replicas, 1)
+        self.assertIsNone(deploy.resources)
+        self.assertIsNone(deploy.placement)
 
     def test_deploy_with_replicas_and_resources(self):
         """ deploy field with replicas, resources, and placement """


### PR DESCRIPTION
# Always provide a default `Deploy` configuration

## Summary

This PR changes `OpenFactoryAppSchema` so that every application always has a valid `Deploy` configuration, even when the `deploy` section is omitted from the YAML file.

Instead of defaulting `deploy` to `None`, the schema now creates a default `Deploy` instance using `default_factory=Deploy`.

## Motivation

The `Deploy` model already defines sensible defaults, including `replicas=1`. Returning `None` therefore provides little benefit while requiring deployment code to repeatedly check whether a deployment configuration exists before accessing its properties.

With this change, deployment code can directly use:

```python
application.deploy.replicas
```

without first testing whether `application.deploy` is `None`.

This simplifies the deployment logic and prepares the codebase for upcoming improvements to deployment strategies.

## Changes

* Changed `OpenFactoryAppSchema.deploy` to use `default_factory=Deploy`.
* Updated unit tests to verify that:

  * a default `Deploy` instance is created when the `deploy` section is omitted;
  * default values are correctly initialized.

## Backward Compatibility

This change is fully backward compatible.

Existing application YAML files continue to work unchanged. Applications that omit the `deploy` section now automatically receive a default deployment configuration instead of `None`.
