### PR TITLE
Add replica support to the local Docker deployment strategy

### DIFF
--- a/openfactory/openfactory_deploy_strategy.py
+++ b/openfactory/openfactory_deploy_strategy.py
@@ -11,8 +11,9 @@ Key Components:
   for service deployment and removal. Subclasses must implement `deploy` and `remove`.
 - **SwarmDeploymentStrategy**: Deploys services in Docker Swarm mode, supporting
   service replication, placement constraints, networks, mounts, and resource limits.
-- **LocalDockerDeploymentStrategy**: Deploys single Docker containers locally
-  (non-Swarm), primarily for development or testing.
+- **LocalDockerDeploymentStrategy**: Deploys one or more Docker containers
+  locally (non-Swarm), including emulation of Swarm service replication for
+  development and testing.
 
 Features:
 ---------
@@ -77,6 +78,7 @@ from docker.types import Mount, DriverConfig, Ulimit, ContainerSpec, TaskTemplat
 from abc import ABC, abstractmethod
 from typing import List, Dict, Optional, Any, Literal
 from openfactory.docker.docker_access_layer import dal
+from openfactory.exceptions import OFAConfigurationException
 
 
 ImagePullPolicy = Literal["missing", "always"]
@@ -122,7 +124,10 @@ class OpenFactoryServiceDeploymentStrategy(ABC):
             open_files (Optional[int]): Maximum number of open file descriptors
                 (RLIMIT_NOFILE) available to the process inside the container.
                 If not specified, the container runtime default is used.
-            mode (Optional[Dict[str, Any]]): Service mode (Swarm only).
+            mode (Optional[Dict[str, Any]]):
+                Deployment mode. Docker Swarm uses this value directly, while the
+                local Docker strategy uses the replica count to emulate replicated
+                services.
             mounts (Optional[List[dict]]): List of Docker mount specifications.
         """
         pass
@@ -218,7 +223,26 @@ class SwarmDeploymentStrategy(OpenFactoryServiceDeploymentStrategy):
 
 
 class LocalDockerDeploymentStrategy(OpenFactoryServiceDeploymentStrategy):
-    """ Deployment strategy for local Docker containers (non-Swarm). """
+    """
+    Deployment strategy for local Docker containers (non-Swarm).
+
+    Supports deployment of both single-container applications and local
+    emulation of Docker Swarm service replication.
+
+    Replica naming follows the convention:
+
+    - Single replica:
+        - Container name: ``<container-name>``
+        - ``APP_UUID``: unchanged
+
+    - Multiple replicas:
+        - Container names: ``<container-name>-1``, ``<container-name>-2``, ...
+        - ``APP_UUID`` values: ``<app-uuid>-1``, ``<app-uuid>-2``, ...
+
+    The container name and ``APP_UUID`` are treated independently. The original
+    container name is used as the base for replica container names, while the
+    original ``APP_UUID`` is preserved and suffixed with the replica number.
+    """
 
     def swarm_mount_to_container_mount(self, mount_dict: dict) -> Mount:
         """
@@ -254,6 +278,45 @@ class LocalDockerDeploymentStrategy(OpenFactoryServiceDeploymentStrategy):
             driver_config=driver_config
         )
 
+    def get_env_var(self, env: List[str], key: str) -> str:
+        """
+        Return the value of an environment variable.
+
+        Args:
+            env: Environment variables in ``KEY=value`` format.
+            key: Environment variable name.
+
+        Returns:
+            The value associated with ``key``.
+
+        Raises:
+            KeyError: If the environment variable does not exist.
+        """
+        prefix = f"{key}="
+        for item in env:
+            if item.startswith(prefix):
+                return item[len(prefix):]
+        raise KeyError(f"Environment variable '{key}' not found.")
+
+    def replace_env_var(self, env: List[str], key: str, value: str) -> List[str]:
+        """
+        Return a copy of an environment variable list with ``key`` set to ``value``.
+
+        Any existing definition of ``key`` is replaced with the supplied value.
+        If the variable does not exist, it is appended.
+
+        Args:
+            env: Environment variables in ``KEY=value`` format.
+            key: Environment variable name.
+            value: New value for the environment variable.
+
+        Returns:
+            A new environment variable list.
+        """
+        new_env = [e for e in env if not e.startswith(f"{key}=")]
+        new_env.append(f"{key}={value}")
+        return new_env
+
     def deploy(self, *,
                image: str,
                image_pull_policy: ImagePullPolicy = "missing",
@@ -270,27 +333,41 @@ class LocalDockerDeploymentStrategy(OpenFactoryServiceDeploymentStrategy):
                mode: Optional[Dict[str, Any]] = None,
                mounts: Optional[List[dict]] = None) -> None:
         """
-        Run a local Docker container.
+        Run one or more local Docker containers.
 
         See parent method for argument descriptions.
 
-        Note:
-            - ``constraints`` and ``mode`` are ignored for local containers.
+        Notes:
+            - ``constraints`` are ignored for local containers.
+            - ``mode["Replicated"]["Replicas"]`` determines the number of local containers to create.
+            - Replicated containers are named ``<name>-1``, ``<name>-2``, ... and receive matching ``APP_UUID`` environment variables.
+            - Host port mappings are not supported when deploying multiple replicas.
             - ``image_pull_policy="always"`` forces a Docker image pull before deployment.
             - When ``open_files`` is specified, a ``nofile`` ulimit is configured with identical soft and hard limits.
-            - If ``open_files`` is not specified, the Docker Engine default file descriptor limit is used.
         """
         client = docker.from_env()
+
+        replicas = mode.get("Replicated", {}).get("Replicas", 1) if mode else 1
+
+        if replicas > 1 and ports:
+            raise OFAConfigurationException(
+                "Host port mappings are not supported when deploying multiple "
+                "replicas with LocalDockerDeploymentStrategy."
+            )
 
         # Convert dict mounts to docker.types.Mount for local Docker
         docker_mounts = []
         if mounts:
             for m in mounts:
                 if m["Type"].lower() == "bind":
-                    docker_mounts.append(Mount(target=m["Target"],
-                                               source=m["Source"],
-                                               type="bind",
-                                               read_only=m.get("ReadOnly", False)))
+                    docker_mounts.append(
+                        Mount(
+                            target=m["Target"],
+                            source=m["Source"],
+                            type="bind",
+                            read_only=m.get("ReadOnly", False),
+                        )
+                    )
                 elif m["Type"].lower() == "volume":
                     docker_mounts.append(self.swarm_mount_to_container_mount(m))
                 else:
@@ -309,39 +386,74 @@ class LocalDockerDeploymentStrategy(OpenFactoryServiceDeploymentStrategy):
                 )
             ]
 
-        container = client.containers.run(
-            image=image,
-            user=user,
-            name=name,
-            environment=env,
-            command=command,
-            detach=True,
-            ports={f"{container_port}/tcp": host_port for host_port, container_port in ports.items()} if ports else None,
-            network=networks[0] if networks else None,
-            labels=labels,
-            nano_cpus=resources.get("Limits", {}).get("NanoCPUs") if resources else None,
-            mounts=docker_mounts,
-            ulimits=ulimits
-        )
+        containers = []
+        base_app_uuid = self.get_env_var(env, "APP_UUID")
 
-        # Attach to additional networks
+        for replica in range(replicas):
+
+            if replicas == 1:
+                replica_name = name
+                replica_env = env
+            else:
+                replica_name = f"{name}-{replica + 1}"
+                replica_env = self.replace_env_var(env, "APP_UUID", f"{base_app_uuid}-{replica + 1}")
+
+            container = client.containers.run(
+                image=image,
+                user=user,
+                name=replica_name,
+                environment=replica_env,
+                command=command,
+                detach=True,
+                ports={
+                    f"{container_port}/tcp": host_port
+                    for host_port, container_port in ports.items()
+                } if ports else None,
+                network=networks[0] if networks else None,
+                labels=labels,
+                nano_cpus=resources.get("Limits", {}).get("NanoCPUs")
+                if resources else None,
+                mounts=docker_mounts,
+                ulimits=ulimits,
+            )
+
+            containers.append(container)
+
+        # Attach each container to any additional networks.
         if networks:
-            for net_name in networks[1:]:
-                network = client.networks.get(net_name)
-                network.connect(container)
+            for container in containers:
+                for net_name in networks[1:]:
+                    client.networks.get(net_name).connect(container)
 
     def remove(self, service_name):
         """
-        Remove a Docker container.
+        Remove one or more local Docker containers.
+
+        If the application was deployed as a single container, the container
+        named ``service_name`` is removed.
+
+        If the application was deployed with local replication, all containers
+        whose names follow the ``service_name-N`` naming convention are removed.
 
         Args:
-            service_name (str): Docker container to be removed.
+            service_name (str): Base name of the Docker container(s) to remove.
 
         Raises:
-            docker.errors.NotFound: If the container does not exist.
-            docker.errors.APIError: If removal fails due to a Docker API issue.
+            docker.errors.NotFound: If no matching container exists.
+            docker.errors.APIError: If removal of any matching container fails due to a Docker API issue.
         """
         client = docker.from_env()
-        container = client.containers.get(service_name)
-        container.stop()
-        container.remove()
+
+        containers = [
+            container
+            for container in client.containers.list(all=True)
+            if container.name == service_name
+            or container.name.startswith(f"{service_name}-")
+        ]
+
+        if not containers:
+            raise docker.errors.NotFound(f"No Docker container found for service '{service_name}'.")
+
+        for container in containers:
+            container.stop()
+            container.remove()

--- a/openfactory/openfactory_manager.py
+++ b/openfactory/openfactory_manager.py
@@ -289,7 +289,7 @@ class OpenFactoryManager(OpenFactory):
                 image_pull_policy=application.image_pull_policy,
                 user=runtime_user,
                 name=application.uuid.lower(),
-                mode={"Replicated": {"Replicas": 1}},
+                mode={"Replicated": {"Replicas": application.deploy.replicas}},
                 env=env,
                 resources=resources(application.deploy),
                 open_files=open_files_limit(application.deploy),

--- a/tests/openfactory/test_openfactory_deploy_strategy.py
+++ b/tests/openfactory/test_openfactory_deploy_strategy.py
@@ -1,7 +1,9 @@
 import unittest
+import docker
 from unittest.mock import patch, MagicMock
 from docker.types import DriverConfig
 from openfactory.openfactory_deploy_strategy import SwarmDeploymentStrategy, LocalDockerDeploymentStrategy
+from openfactory.exceptions import OFAConfigurationException
 
 
 class TestSwarmDeploymentStrategy(unittest.TestCase):
@@ -240,7 +242,7 @@ class TestLocalDockerDeploymentStrategy(unittest.TestCase):
         strategy.deploy(
             image="test-image",
             name="test-container",
-            env=["ENV=dev"],
+            env=["APP_UUID=test-container", "ENV=dev"],
             labels={"type": "api"},
             command="start",
             ports={8080: 80},
@@ -252,7 +254,7 @@ class TestLocalDockerDeploymentStrategy(unittest.TestCase):
         args, kwargs = mock_run.call_args
         self.assertEqual(kwargs["image"], "test-image")
         self.assertEqual(kwargs["name"], "test-container")
-        self.assertEqual(kwargs["environment"], ["ENV=dev"])
+        self.assertEqual(kwargs["environment"], ["APP_UUID=test-container", "ENV=dev"])
         self.assertEqual(kwargs["command"], "start")
         self.assertTrue(kwargs["detach"])
         self.assertEqual(kwargs["ports"], {"80/tcp": 8080})
@@ -275,7 +277,7 @@ class TestLocalDockerDeploymentStrategy(unittest.TestCase):
             image="test-image",
             image_pull_policy="always",
             name="test-container",
-            env=["ENV=dev"]
+            env=["APP_UUID=dev", "ENV=dev"]
         )
 
         mock_client.images.pull.assert_called_once_with("test-image")
@@ -294,7 +296,7 @@ class TestLocalDockerDeploymentStrategy(unittest.TestCase):
             image="test-image",
             image_pull_policy="missing",
             name="test-container",
-            env=["ENV=dev"]
+            env=["APP_UUID=dev", "ENV=dev"]
         )
 
         mock_client.images.pull.assert_not_called()
@@ -315,7 +317,7 @@ class TestLocalDockerDeploymentStrategy(unittest.TestCase):
         strategy.deploy(
             image="test-image",
             name="test-container",
-            env=["ENV=dev"],
+            env=["APP_UUID=dev", "ENV=dev"],
             user="1234:5678"
         )
 
@@ -327,19 +329,20 @@ class TestLocalDockerDeploymentStrategy(unittest.TestCase):
         self.assertEqual(kwargs["user"], "1234:5678")
 
     @patch("openfactory.openfactory_deploy_strategy.docker.from_env")
-    def test_local_remove(self, mock_from_env):
-        """ Test local Docker remove performs a graceful shutdown before removal. """
-        mock_docker_client = MagicMock()
+    def test_local_remove_single_container(self, mock_from_env):
+        """ Test local Docker remove removes a single container """
+        mock_client = MagicMock()
         mock_container = MagicMock()
-        mock_docker_client.containers.get.return_value = mock_container
-        mock_from_env.return_value = mock_docker_client
+
+        mock_container.name = "test-container"
+        mock_client.containers.list.return_value = [mock_container]
+        mock_from_env.return_value = mock_client
 
         strategy = LocalDockerDeploymentStrategy()
         strategy.remove("test-container")
 
-        mock_docker_client.containers.get.assert_called_once_with("test-container")
+        mock_client.containers.list.assert_called_once_with(all=True)
 
-        # Verify graceful shutdown sequence
         self.assertEqual(
             mock_container.method_calls,
             [
@@ -348,8 +351,62 @@ class TestLocalDockerDeploymentStrategy(unittest.TestCase):
             ]
         )
 
-        mock_container.stop.assert_called_once_with()
-        mock_container.remove.assert_called_once_with()
+    @patch("openfactory.openfactory_deploy_strategy.docker.from_env")
+    def test_local_remove_multiple_replicas(self, mock_from_env):
+        """ Test local Docker remove removes all replicated containers """
+        mock_client = MagicMock()
+
+        container1 = MagicMock()
+        container1.name = "test-container-1"
+
+        container2 = MagicMock()
+        container2.name = "test-container-2"
+
+        container3 = MagicMock()
+        container3.name = "test-container-3"
+
+        unrelated = MagicMock()
+        unrelated.name = "another-container"
+
+        mock_client.containers.list.return_value = [unrelated, container1, container2, container3]
+
+        mock_from_env.return_value = mock_client
+
+        strategy = LocalDockerDeploymentStrategy()
+
+        strategy.remove("test-container")
+
+        mock_client.containers.list.assert_called_once_with(all=True)
+
+        for container in (container1, container2, container3):
+            self.assertEqual(
+                container.method_calls,
+                [
+                    unittest.mock.call.stop(),
+                    unittest.mock.call.remove(),
+                ]
+            )
+
+        unrelated.stop.assert_not_called()
+        unrelated.remove.assert_not_called()
+
+    @patch("openfactory.openfactory_deploy_strategy.docker.from_env")
+    def test_local_remove_container_not_found(self, mock_from_env):
+        """ Test local Docker remove raises NotFound when no matching container exists """
+        mock_client = MagicMock()
+
+        other = MagicMock()
+        other.name = "another-container"
+
+        mock_client.containers.list.return_value = [other]
+        mock_from_env.return_value = mock_client
+
+        strategy = LocalDockerDeploymentStrategy()
+
+        with self.assertRaises(docker.errors.NotFound):
+            strategy.remove("test-container")
+
+        mock_client.containers.list.assert_called_once_with(all=True)
 
     @patch("openfactory.openfactory_deploy_strategy.docker.from_env")
     @patch("openfactory.openfactory_deploy_strategy.Mount")
@@ -373,7 +430,7 @@ class TestLocalDockerDeploymentStrategy(unittest.TestCase):
         strategy.deploy(
             image="test-image",
             name="test-container",
-            env=["ENV=dev"],
+            env=["APP_UUID=dev", "ENV=dev"],
             networks=None,
             mounts=mounts
         )
@@ -454,7 +511,7 @@ class TestLocalDockerDeploymentStrategy(unittest.TestCase):
         strategy.deploy(
             image="test-image",
             name="test-container",
-            env=["ENV=dev"],
+            env=["APP_UUID=dev", "ENV=dev"],
             networks=networks
         )
 
@@ -475,7 +532,7 @@ class TestLocalDockerDeploymentStrategy(unittest.TestCase):
         strategy.deploy(
             image="test-image",
             name="test-container-2",
-            env=["ENV=dev"],
+            env=["APP_UUID=dev", "ENV=dev"],
             networks=["only-net"]
         )
         # containers.run should use the single network
@@ -488,7 +545,7 @@ class TestLocalDockerDeploymentStrategy(unittest.TestCase):
         strategy.deploy(
             image="test-image",
             name="test-container-3",
-            env=["ENV=dev"],
+            env=["APP_UUID=dev", "ENV=dev"],
             networks=None
         )
         _, kwargs = mock_client.containers.run.call_args
@@ -511,7 +568,7 @@ class TestLocalDockerDeploymentStrategy(unittest.TestCase):
         strategy.deploy(
             image="test-image",
             name="test-container-single-net",
-            env=["ENV=dev"],
+            env=["APP_UUID=dev", "ENV=dev"],
             networks=networks
         )
 
@@ -540,7 +597,7 @@ class TestLocalDockerDeploymentStrategy(unittest.TestCase):
         strategy.deploy(
             image="test-image",
             name="test-container",
-            env=["ENV=dev"],
+            env=["APP_UUID=dev", "ENV=dev"],
             open_files=5000
         )
 
@@ -564,10 +621,180 @@ class TestLocalDockerDeploymentStrategy(unittest.TestCase):
         strategy.deploy(
             image="test-image",
             name="test-container",
-            env=["ENV=dev"]
+            env=["APP_UUID=dev", "ENV=dev"]
         )
 
         mock_ulimit.assert_not_called()
         _, kwargs = mock_client.containers.run.call_args
         self.assertIn("ulimits", kwargs)
         self.assertIsNone(kwargs["ulimits"])
+
+    @patch("openfactory.openfactory_deploy_strategy.docker.from_env")
+    def test_local_deploy_multiple_replicas(self, mock_from_env):
+        """ Replicated deployment should create one container per replica. """
+
+        mock_client = MagicMock()
+        mock_client.containers.run.return_value = MagicMock()
+        mock_from_env.return_value = mock_client
+
+        strategy = LocalDockerDeploymentStrategy()
+
+        strategy.deploy(
+            image="test-image",
+            name="demo-app",
+            env=["APP_UUID=TEST-APP", "FOO=bar"],
+            mode={"Replicated": {"Replicas": 3}},
+        )
+
+        self.assertEqual(mock_client.containers.run.call_count, 3)
+
+        calls = mock_client.containers.run.call_args_list
+
+        self.assertEqual(calls[0].kwargs["name"], "demo-app-1")
+        self.assertEqual(calls[1].kwargs["name"], "demo-app-2")
+        self.assertEqual(calls[2].kwargs["name"], "demo-app-3")
+
+        self.assertIn("APP_UUID=TEST-APP-1", calls[0].kwargs["environment"])
+        self.assertIn("APP_UUID=TEST-APP-2", calls[1].kwargs["environment"])
+        self.assertIn("APP_UUID=TEST-APP-3", calls[2].kwargs["environment"])
+
+    @patch("openfactory.openfactory_deploy_strategy.docker.from_env")
+    def test_local_deploy_single_replica_keeps_original_name(self, mock_from_env):
+        """ Test local Docker deploy with a single replica preserves the original container name and APP_UUID """
+        mock_client = MagicMock()
+        mock_container = MagicMock()
+        mock_client.containers.run.return_value = mock_container
+        mock_from_env.return_value = mock_client
+
+        strategy = LocalDockerDeploymentStrategy()
+
+        strategy.deploy(
+            image="test-image",
+            name="test-container",
+            env=["APP_UUID=test-container", "ENV=dev"],
+            mode={"Replicated": {"Replicas": 1}}
+        )
+
+        mock_client.containers.run.assert_called_once()
+
+        _, kwargs = mock_client.containers.run.call_args
+
+        self.assertEqual(kwargs["name"], "test-container")
+        self.assertEqual(kwargs["environment"], ["APP_UUID=test-container", "ENV=dev"])
+
+    @patch("openfactory.openfactory_deploy_strategy.docker.from_env")
+    def test_local_deploy_multiple_replicas_with_ports_fails(self, mock_from_env):
+        """ Test local Docker deploy rejects host port mappings when deploying multiple replicas """
+        strategy = LocalDockerDeploymentStrategy()
+
+        with self.assertRaises(OFAConfigurationException):
+            strategy.deploy(
+                image="test",
+                name="demo",
+                env=[],
+                ports={8080: 80},
+                mode={"Replicated": {"Replicas": 2}},
+            )
+
+    @patch("openfactory.openfactory_deploy_strategy.docker.from_env")
+    def test_local_deploy_multiple_replicas_additional_networks(self, mock_from_env):
+        """ Test local Docker deploy connects each replica to every additional Docker network """
+        mock_client = MagicMock()
+
+        container1 = MagicMock()
+        container2 = MagicMock()
+        container3 = MagicMock()
+
+        mock_client.containers.run.side_effect = [container1, container2, container3]
+
+        second_network = MagicMock()
+        third_network = MagicMock()
+
+        def get_network(name):
+            if name == "second-net":
+                return second_network
+            if name == "third-net":
+                return third_network
+            self.fail(f"Unexpected network requested: {name}")
+
+        mock_client.networks.get.side_effect = get_network
+        mock_from_env.return_value = mock_client
+
+        strategy = LocalDockerDeploymentStrategy()
+
+        strategy.deploy(
+            image="test-image",
+            name="test-container",
+            env=["APP_UUID=dev", "ENV=dev"],
+            networks=["first-net", "second-net", "third-net"],
+            mode={"Replicated": {"Replicas": 3}},
+        )
+
+        # Three containers should be started.
+        self.assertEqual(mock_client.containers.run.call_count, 3)
+
+        # Every container should use the first network directly.
+        for call in mock_client.containers.run.call_args_list:
+            self.assertEqual(call.kwargs["network"], "first-net")
+
+        # Both additional networks should be looked up once per replica.
+        self.assertEqual(
+            mock_client.networks.get.call_args_list,
+            [
+                unittest.mock.call("second-net"),
+                unittest.mock.call("third-net"),
+                unittest.mock.call("second-net"),
+                unittest.mock.call("third-net"),
+                unittest.mock.call("second-net"),
+                unittest.mock.call("third-net"),
+            ],
+        )
+
+        # Every replica should be connected to every additional network.
+        second_network.connect.assert_has_calls(
+            [
+                unittest.mock.call(container1),
+                unittest.mock.call(container2),
+                unittest.mock.call(container3),
+            ]
+        )
+
+        third_network.connect.assert_has_calls(
+            [
+                unittest.mock.call(container1),
+                unittest.mock.call(container2),
+                unittest.mock.call(container3),
+            ]
+        )
+
+    def test_replace_env_var(self):
+        """ Test replace_env_var replaces an existing environment variable or appends a new one """
+        strategy = LocalDockerDeploymentStrategy()
+
+        env = [
+            "VAR1=value1",
+            "APP_UUID=old-value",
+            "VAR2=value2"
+        ]
+
+        new_env = strategy.replace_env_var(env, "APP_UUID", "new-value")
+        self.assertEqual(new_env, ["VAR1=value1", "VAR2=value2", "APP_UUID=new-value"])
+
+        new_env = strategy.replace_env_var(["VAR1=value1"], "APP_UUID", "new-value")
+        self.assertEqual(new_env, ["VAR1=value1", "APP_UUID=new-value"])
+
+    def test_get_env_var(self):
+        """ Test get_env_var returns the value of an environment variable or raises KeyError if not found """
+        strategy = LocalDockerDeploymentStrategy()
+
+        env = [
+            "VAR1=value1",
+            "APP_UUID=TEST-APP",
+            "VAR2=value2"
+        ]
+
+        self.assertEqual(strategy.get_env_var(env, "APP_UUID"), "TEST-APP")
+        self.assertEqual(strategy.get_env_var(env, "VAR1"), "value1")
+        with self.assertRaises(KeyError):
+            strategy.get_env_var(env, "UNKNOWN")
+

--- a/tests/openfactory/test_openfactory_deploy_strategy.py
+++ b/tests/openfactory/test_openfactory_deploy_strategy.py
@@ -797,4 +797,3 @@ class TestLocalDockerDeploymentStrategy(unittest.TestCase):
         self.assertEqual(strategy.get_env_var(env, "VAR1"), "value1")
         with self.assertRaises(KeyError):
             strategy.get_env_var(env, "UNKNOWN")
-

--- a/tests/openfactory/test_openfactorymanager.py
+++ b/tests/openfactory/test_openfactorymanager.py
@@ -526,6 +526,24 @@ class TestOpenFactoryManager(unittest.TestCase):
 
     @patch("openfactory.openfactory_manager.register_asset")
     @patch("openfactory.openfactory_manager.user_notify")
+    def test_deploy_openfactory_application_passes_replicas(self, mock_user_notify, mock_register_asset):
+        """ Configured replica count should be forwarded to the deployment strategy. """
+
+        app = OpenFactoryAppSchema(
+            uuid="APP_REPLICAS",
+            image="app_image",
+            deploy=Deploy(replicas=3)
+        )
+
+        self.manager.deploy_openfactory_application(app)
+
+        deploy_call = self.manager.deployment_strategy.deploy.call_args
+        kwargs = deploy_call.kwargs
+
+        self.assertEqual(kwargs["mode"], {"Replicated": {"Replicas": 3}})
+
+    @patch("openfactory.openfactory_manager.register_asset")
+    @patch("openfactory.openfactory_manager.user_notify")
     def test_deploy_openfactory_application_runtime_user(self, mock_user_notify, mock_register_asset):
         """ runtime UID/GID should be passed to deployment strategy """
         app = OpenFactoryAppSchema(


### PR DESCRIPTION
# Add replica support to the local Docker deployment strategy

## Summary

This PR extends `LocalDockerDeploymentStrategy` to support replicated application deployments, providing behavior similar to Docker Swarm when running OpenFactory on a local Docker engine.

When multiple replicas are requested, the strategy now launches one Docker container per replica using deterministic container names and replica-specific `APP_UUID` values.

## Motivation

Docker Swarm natively supports replicated services, while the local Docker deployment strategy previously always deployed a single container.

Supporting replication locally allows developers to test and debug multi-instance OpenFactory applications without requiring a Swarm cluster.

## Changes

### Replicated deployments

* Added support for the Swarm deployment mode when using the local Docker deployment strategy.
* One Docker container is created for each requested replica.
* Replica naming follows the convention:

  * Single replica:

    * Container name: `<container-name>`
    * `APP_UUID`: unchanged
  * Multiple replicas:

    * Container names: `<container-name>-1`, `<container-name>-2`, ...
    * `APP_UUID` values: `<app-uuid>-1`, `<app-uuid>-2`, ...

### Environment handling

* Added helper methods to retrieve and replace environment variables in `KEY=value` lists.
* Replica-specific `APP_UUID` values are generated automatically while preserving all other environment variables.

### Networking

* All replicas are attached to the configured Docker networks.
* The first network is used during container creation, with any additional networks connected afterwards, matching the previous behavior.

### Port mappings

* Local replicated deployments now reject host port mappings.
* Since multiple local containers cannot bind the same host port, attempting to deploy multiple replicas with published ports raises an `OFAConfigurationException`.

### Container removal

* Updated the local Docker removal logic to support both:

  * legacy single-container deployments; and
  * replicated deployments using the `<container-name>-N` naming convention.

## Testing

Added unit tests covering:

* Single-replica deployment.
* Multi-replica deployment.
* Replica-specific container names.
* Replica-specific `APP_UUID` values.
* Rejection of host port mappings for replicated deployments.
* Connection of every replica to all configured Docker networks.
* Removal of legacy single-container deployments.
* Removal of replicated deployments.
* Removal of non-existent deployments.
* Environment variable helper methods.

## Backward Compatibility

This change is fully backward compatible.

Applications configured with a single replica continue to behave exactly as before. Replicated deployments become available automatically when `deploy.replicas` is greater than one.
