### PR TITLE
Add replicas_uuid() helper to OpenFactoryAppSchema

### DIFF
--- a/openfactory/schemas/apps.py
+++ b/openfactory/schemas/apps.py
@@ -396,6 +396,13 @@ class OpenFactoryAppSchema(AttachUNSMixin, BaseModel):
             )
         return self
 
+    def replicas_uuid(self) -> list[str]:
+        """ Return the ASSET_UUIDs of all application replicas. """
+        if self.deploy.replicas == 1:
+            return [self.uuid]
+
+        return [f"{self.uuid}-{i}" for i in range(1, self.deploy.replicas + 1)]
+
 
 class OpenFactoryAppsConfig(BaseModel):
     """

--- a/tests/openfactory/schemas/test_apps.py
+++ b/tests/openfactory/schemas/test_apps.py
@@ -950,3 +950,41 @@ class TestOpenFactoryAppsConfig(unittest.TestCase):
 
         self.assertEqual(metrics.port, 4000)
         self.assertEqual(metrics.path, "/metrics")
+
+    def test_replicas_uuid_single_replica(self):
+        """ A single replica should return the original UUID """
+
+        config = OpenFactoryAppsConfig(
+            apps={
+                "demo1": {
+                    "uuid": "DEMO-APP",
+                    "image": "demofact/demo1",
+                }
+            }
+        )
+
+        self.assertEqual(config.apps["demo1"].replicas_uuid(), ["DEMO-APP"])
+
+    def test_replicas_uuid_multiple_replicas(self):
+        """ Multiple replicas should receive numbered UUIDs """
+
+        config = OpenFactoryAppsConfig(
+            apps={
+                "demo1": {
+                    "uuid": "DEMO-APP",
+                    "image": "demofact/demo1",
+                    "deploy": {
+                        "replicas": 3,
+                    },
+                }
+            }
+        )
+
+        self.assertEqual(
+            config.apps["demo1"].replicas_uuid(),
+            [
+                "DEMO-APP-1",
+                "DEMO-APP-2",
+                "DEMO-APP-3",
+            ],
+        )


### PR DESCRIPTION
# Add `replicas_uuid()` helper to `OpenFactoryAppSchema`

## Summary

This PR adds a `replicas_uuid()` helper method to `OpenFactoryAppSchema` that returns the UUIDs of all application replicas based on the configured replica count.

## Changes

* Added `OpenFactoryAppSchema.replicas_uuid()`.
* Added an explicit return type hint (`list[str]`).
* Added unit tests covering:

  * single-replica deployments
  * multi-replica deployments

## Example

For:

```yaml
deploy:
  replicas: 3
uuid: DEMO-APP
```

`replicas_uuid()` returns:

```python
["DEMO-APP-1", "DEMO-APP-2", "DEMO-APP-3"]
```

For the default single replica:

```python
["DEMO-APP"]
```

## Motivation

This provides a single, reusable implementation for generating replica UUIDs, avoiding duplicated logic and ensuring consistent replica naming across the OpenFactory codebase.
