### PR TITLE
Support replica-aware application teardown

### DIFF
--- a/openfactory/monitoring/utils.py
+++ b/openfactory/monitoring/utils.py
@@ -1,4 +1,5 @@
 import json
+import openfactory.config as config
 from openfactory.kafka.ksql import KSQLDBClient
 from openfactory.kafka import AssetProducer
 from openfactory.schemas.apps import OpenFactoryAppSchema
@@ -14,27 +15,32 @@ def discover_prometheus_registry(ksqlClient: KSQLDBClient):
     return registry[0]['ASSET_UUID']
 
 
-def register_prometheus_target(target: OpenFactoryAppSchema,
+def register_prometheus_target(app: OpenFactoryAppSchema,
                                ksqlClient: KSQLDBClient, bootstrap_servers: str):
     """
     Register a new Prometheus target
 
     Args:
-        target (OpenFactoryAppSchema): target to register.
+        app (OpenFactoryAppSchema): OpenFactory app to register.
         ksqlClient: (KSQLDBClient) KSQL client for executing queries.
         bootstrap_servers (str): Kafka bootstrap server address.
     """
+    # only for docker deployment platform
+    if not config.DEPLOYMENT_PLATFORM == 'docker':
+        return
+
     topic = ksqlClient.get_kafka_topic('METRICS_TARGETS_SOURCE')
     producer = AssetProducer(ksqlClient=ksqlClient, bootstrap_servers=bootstrap_servers)
-    producer.produce(
-        topic=topic,
-        key=target.uuid,
-        value=json.dumps({
-            "HOST": target.uuid.lower(),
-            "PORT": str(target.metrics.port),
-            "PATH": target.metrics.path
-        })
-    )
+    for rep_uuid in app.replicas_uuid():
+        producer.produce(
+            topic=topic,
+            key=rep_uuid,
+            value=json.dumps({
+                "HOST": rep_uuid.lower(),
+                "PORT": str(app.metrics.port),
+                "PATH": app.metrics.path
+            })
+        )
     producer.flush()
 
 

--- a/openfactory/openfactory_deploy_strategy.py
+++ b/openfactory/openfactory_deploy_strategy.py
@@ -78,6 +78,7 @@ from docker.types import Mount, DriverConfig, Ulimit, ContainerSpec, TaskTemplat
 from abc import ABC, abstractmethod
 from typing import List, Dict, Optional, Any, Literal
 from openfactory.docker.docker_access_layer import dal
+from openfactory.schemas.apps import OpenFactoryAppSchema
 from openfactory.exceptions import OFAConfigurationException
 
 
@@ -133,12 +134,12 @@ class OpenFactoryServiceDeploymentStrategy(ABC):
         pass
 
     @abstractmethod
-    def remove(self, service_name):
+    def remove(self, application: OpenFactoryAppSchema):
         """
         Remove a service.
 
         Args:
-            service_name (str): Service to be removed.
+            application (OpenFactoryAppSchema): The application to be removed.
         """
         pass
 
@@ -211,14 +212,14 @@ class SwarmDeploymentStrategy(OpenFactoryServiceDeploymentStrategy):
             endpoint_spec=EndpointSpec(ports=ports) if ports else None
         )
 
-    def remove(self, service_name):
+    def remove(self, application: OpenFactoryAppSchema):
         """
         Remove a Docker service from a Docker Swarm cluster.
 
         Args:
-            service_name (str): Docker swarm service to be removed.
+            appliacation (OpenFactoryAppSchema): OpenFactory application to be removed.
         """
-        service = dal.docker_client.services.get(service_name)
+        service = dal.docker_client.services.get(application.uuid.lower())
         service.remove()
 
 
@@ -425,18 +426,18 @@ class LocalDockerDeploymentStrategy(OpenFactoryServiceDeploymentStrategy):
                 for net_name in networks[1:]:
                     client.networks.get(net_name).connect(container)
 
-    def remove(self, service_name):
+    def remove(self, application: OpenFactoryAppSchema):
         """
         Remove one or more local Docker containers.
 
         If the application was deployed as a single container, the container
-        named ``service_name`` is removed.
+        named ``application.uuid.lower()`` is removed.
 
         If the application was deployed with local replication, all containers
-        whose names follow the ``service_name-N`` naming convention are removed.
+        whose names follow the ``application.uuid.lower()-N`` naming convention are removed.
 
         Args:
-            service_name (str): Base name of the Docker container(s) to remove.
+            application (OpenFactoryAppSchema): application to remove.
 
         Raises:
             docker.errors.NotFound: If no matching container exists.
@@ -447,12 +448,12 @@ class LocalDockerDeploymentStrategy(OpenFactoryServiceDeploymentStrategy):
         containers = [
             container
             for container in client.containers.list(all=True)
-            if container.name == service_name
-            or container.name.startswith(f"{service_name}-")
+            if container.name == application.uuid.lower()
+            or container.name.startswith(f"{application.uuid.lower()}-")
         ]
 
         if not containers:
-            raise docker.errors.NotFound(f"No Docker container found for service '{service_name}'.")
+            raise docker.errors.NotFound(f"No Docker container found for application '{application.uuid}'.")
 
         for container in containers:
             container.stop()

--- a/openfactory/openfactory_manager.py
+++ b/openfactory/openfactory_manager.py
@@ -49,7 +49,6 @@ from openfactory.schemas.devices import get_devices_from_config_file
 from openfactory.schemas.apps import OpenFactoryAppSchema, get_apps_from_config_file, normalize_name
 from openfactory.schemas.uns import UNSSchema
 from openfactory.schemas.common import constraints, resources, open_files_limit
-from openfactory.assets import Asset
 from openfactory.exceptions import OFAException
 from openfactory.models.user_notifications import user_notify
 from openfactory.utils import register_asset, deregister_asset, load_plugin, register_device_connector, deregister_device_connector
@@ -302,8 +301,9 @@ class OpenFactoryManager(OpenFactory):
             user_notify.fail(f"Application {application.uuid} could not be deployed\n{err}")
             return
 
-        register_asset(application.uuid, uns=application.uns, asset_type='OpenFactoryApp',
-                       ksqlClient=self.ksql, bootstrap_servers=self.bootstrap_servers, docker_service=application.uuid.lower())
+        for app_uuid in application.replicas_uuid():
+            register_asset(app_uuid, uns=application.uns, asset_type='OpenFactoryApp',
+                           ksqlClient=self.ksql, bootstrap_servers=self.bootstrap_servers, docker_service=app_uuid.lower())
         if application.metrics:
             register_prometheus_target(application, ksqlClient=self.ksql, bootstrap_servers=self.bootstrap_servers)
         user_notify.success(f"Application {application.uuid} deployed successfully")
@@ -458,29 +458,27 @@ class OpenFactoryManager(OpenFactory):
             deregister_device_connector(device.uuid, bootstrap_servers=self.bootstrap_servers)
             user_notify.success(f"Device {device.uuid} shut down successfully")
 
-    def tear_down_application(self, app_uuid: str) -> None:
+    def tear_down_application(self, application: OpenFactoryAppSchema) -> None:
         """
-        Tear down a deployed OpenFactory application.
+        Tear down a deployed OpenFactory application and all of its replicas.
 
         Args:
-            app_uuid (str): The UUID of the application to be torn down.
+            application (OpenFactoryAppSchema): Application to be torn down.
 
         Raises:
-            OFAException: If the application cannot be torn down.
+            OFAException: If a Docker API error prevents the application from being torn down.
         """
         try:
-            app = Asset(app_uuid, ksqlClient=self.ksql, bootstrap_servers=self.bootstrap_servers)
-            self.deployment_strategy.remove(app.DockerService.value)
-            app.close()
+            self.deployment_strategy.remove(application)
         except docker.errors.NotFound:
-            # the application was not running as a Docker swarm service
-            deregister_asset(app_uuid, ksqlClient=self.ksql, bootstrap_servers=self.bootstrap_servers)
+            # The Docker service is already gone. Continue with OpenFactory cleanup.
             pass
         except docker.errors.APIError as err:
             raise OFAException(err)
-        deregister_asset(app_uuid, ksqlClient=self.ksql, bootstrap_servers=self.bootstrap_servers)
-        deregister_prometheus_target(app_uuid, ksqlClient=self.ksql, bootstrap_servers=self.bootstrap_servers)
-        user_notify.success(f"OpenFactory application {app_uuid} shut down successfully")
+        for app_uuid in application.replicas_uuid():
+            deregister_asset(app_uuid, ksqlClient=self.ksql, bootstrap_servers=self.bootstrap_servers)
+            deregister_prometheus_target(app_uuid, ksqlClient=self.ksql, bootstrap_servers=self.bootstrap_servers)
+        user_notify.success(f"OpenFactory application {application.uuid} shut down successfully")
 
     def shut_down_apps_from_config_file(self, yaml_config_file: str) -> None:
         """
@@ -515,7 +513,7 @@ class OpenFactoryManager(OpenFactory):
                 user_notify.info(f"No application {app.uuid} deployed in OpenFactory")
                 continue
 
-            self.tear_down_application(app.uuid)
+            self.tear_down_application(app)
 
     def get_asset_uuid_from_docker_service(self, docker_service_name: str) -> str:
         """

--- a/tests/openfactory/monitoring/test_utils.py
+++ b/tests/openfactory/monitoring/test_utils.py
@@ -1,6 +1,6 @@
 import json
 from unittest import TestCase
-from unittest.mock import patch, MagicMock
+from unittest.mock import call, patch, MagicMock
 from openfactory.monitoring.utils import discover_prometheus_registry, register_prometheus_target, deregister_prometheus_target
 from openfactory.exceptions import OFAException
 
@@ -39,32 +39,69 @@ class TestUtils(TestCase):
 
     @patch("openfactory.monitoring.utils.AssetProducer")
     def test_register_prometheus_target(self, MockAssetProducer):
-        """ Should publish target registration to METRICS_TARGETS_SOURCE. """
+        """ Should publish one Prometheus target registration per replica. """
 
-        target = MagicMock()
-        target.uuid = "APP1"
-        target.metrics = MagicMock()
-        target.metrics.port = 4000
-        target.metrics.path = "/metrics"
+        app = MagicMock()
+        app.replicas_uuid.return_value = ["APP-1", "APP-2"]
+        app.metrics = MagicMock()
+        app.metrics.port = 4000
+        app.metrics.path = "/metrics"
 
         ksql = MagicMock()
         ksql.get_kafka_topic.return_value = "metrics-topic"
         producer = MockAssetProducer.return_value
 
-        register_prometheus_target(target, ksqlClient=ksql, bootstrap_servers="broker:9092")
+        with patch("openfactory.monitoring.utils.config.DEPLOYMENT_PLATFORM", "docker"):
+            register_prometheus_target(app, ksqlClient=ksql, bootstrap_servers="broker:9092")
 
         ksql.get_kafka_topic.assert_called_once_with("METRICS_TARGETS_SOURCE")
         MockAssetProducer.assert_called_once_with(ksqlClient=ksql, bootstrap_servers="broker:9092")
-        producer.produce.assert_called_once_with(
-            topic="metrics-topic",
-            key="APP1",
-            value=json.dumps({
-                "HOST": "app1",
-                "PORT": "4000",
-                "PATH": "/metrics"
-            })
+
+        producer.produce.assert_has_calls(
+            [
+                call(
+                    topic="metrics-topic",
+                    key="APP-1",
+                    value=json.dumps(
+                        {
+                            "HOST": "app-1",
+                            "PORT": "4000",
+                            "PATH": "/metrics",
+                        }
+                    ),
+                ),
+                call(
+                    topic="metrics-topic",
+                    key="APP-2",
+                    value=json.dumps(
+                        {
+                            "HOST": "app-2",
+                            "PORT": "4000",
+                            "PATH": "/metrics",
+                        }
+                    ),
+                ),
+            ]
         )
+        self.assertEqual(producer.produce.call_count, 2)
         producer.flush.assert_called_once()
+
+    @patch("openfactory.monitoring.utils.AssetProducer")
+    def test_register_prometheus_target_non_docker(self, MockAssetProducer):
+        """ Should do nothing when deployment platform is not Docker. """
+
+        app = MagicMock()
+        ksql = MagicMock()
+
+        with patch("openfactory.monitoring.utils.config.DEPLOYMENT_PLATFORM", "not docker"):
+            register_prometheus_target(
+                app,
+                ksqlClient=ksql,
+                bootstrap_servers="broker:9092"
+            )
+
+        ksql.get_kafka_topic.assert_not_called()
+        MockAssetProducer.assert_not_called()
 
     @patch("openfactory.monitoring.utils.AssetProducer")
     def test_deregister_prometheus_target(self, MockAssetProducer):

--- a/tests/openfactory/test_openfactory_deploy_strategy.py
+++ b/tests/openfactory/test_openfactory_deploy_strategy.py
@@ -175,11 +175,13 @@ class TestSwarmDeploymentStrategy(unittest.TestCase):
     @patch("openfactory.openfactory_deploy_strategy.dal.docker_client")
     def test_swarm_remove(self, mock_docker_client):
         """ Test Docker Swarm remove method """
+        app = MagicMock()
+        app.uuid = "TEST-SERVICE"
         mock_service = MagicMock()
         mock_docker_client.services.get.return_value = mock_service
 
         strategy = SwarmDeploymentStrategy()
-        strategy.remove("test-service")
+        strategy.remove(app)
 
         mock_docker_client.services.get.assert_called_once_with("test-service")
         mock_service.remove.assert_called_once_with()
@@ -333,13 +335,15 @@ class TestLocalDockerDeploymentStrategy(unittest.TestCase):
         """ Test local Docker remove removes a single container """
         mock_client = MagicMock()
         mock_container = MagicMock()
+        app = MagicMock()
 
+        app.uuid = "TEST-CONTAINER"
         mock_container.name = "test-container"
         mock_client.containers.list.return_value = [mock_container]
         mock_from_env.return_value = mock_client
 
         strategy = LocalDockerDeploymentStrategy()
-        strategy.remove("test-container")
+        strategy.remove(app)
 
         mock_client.containers.list.assert_called_once_with(all=True)
 
@@ -355,6 +359,9 @@ class TestLocalDockerDeploymentStrategy(unittest.TestCase):
     def test_local_remove_multiple_replicas(self, mock_from_env):
         """ Test local Docker remove removes all replicated containers """
         mock_client = MagicMock()
+        app = MagicMock()
+
+        app.uuid = "TEST-CONTAINER"
 
         container1 = MagicMock()
         container1.name = "test-container-1"
@@ -374,7 +381,7 @@ class TestLocalDockerDeploymentStrategy(unittest.TestCase):
 
         strategy = LocalDockerDeploymentStrategy()
 
-        strategy.remove("test-container")
+        strategy.remove(app)
 
         mock_client.containers.list.assert_called_once_with(all=True)
 
@@ -394,6 +401,9 @@ class TestLocalDockerDeploymentStrategy(unittest.TestCase):
     def test_local_remove_container_not_found(self, mock_from_env):
         """ Test local Docker remove raises NotFound when no matching container exists """
         mock_client = MagicMock()
+        app = MagicMock()
+
+        app.uuid = "TEST-CONTAINER"
 
         other = MagicMock()
         other.name = "another-container"
@@ -404,7 +414,7 @@ class TestLocalDockerDeploymentStrategy(unittest.TestCase):
         strategy = LocalDockerDeploymentStrategy()
 
         with self.assertRaises(docker.errors.NotFound):
-            strategy.remove("test-container")
+            strategy.remove(app)
 
         mock_client.containers.list.assert_called_once_with(all=True)
 

--- a/tests/openfactory/test_openfactorymanager.py
+++ b/tests/openfactory/test_openfactorymanager.py
@@ -1499,99 +1499,104 @@ class TestOpenFactoryManager(unittest.TestCase):
         assert "Device device-fail-1 could not be torn down" in fail_msg
         assert "Mocked teardown failure" in fail_msg
 
-    @patch("openfactory.openfactory_manager.deregister_prometheus_target")
-    @patch("openfactory.openfactory_manager.Asset")
     @patch("openfactory.openfactory_manager.user_notify")
+    @patch("openfactory.openfactory_manager.deregister_prometheus_target")
     @patch("openfactory.openfactory_manager.deregister_asset")
-    def test_tear_down_application(self, mock_deregister_asset, mock_user_notify, MockAsset, mock_deregister_prometheus_target):
+    def test_tear_down_application(self, mock_deregister_asset, mock_deregister_prometheus_target, mock_user_notify):
         """ Test tear_down_application """
 
-        # Mock Asset instance and its DockerService value
-        mock_app_instance = MagicMock()
-        mock_app_instance.DockerService.value = "mock-service-name"
-        MockAsset.return_value = mock_app_instance
+        app = MagicMock()
+        app.uuid = "APP123"
+        app.replicas_uuid.return_value = ["APP123-1", "APP123-2"]
 
-        # Call the method under test
-        app_uuid = 'app-uuid-123'
-        self.manager.tear_down_application(app_uuid)
+        self.manager.tear_down_application(app)
 
-        # Check that the correct service was removed
-        self.manager.deployment_strategy.remove.assert_called_once_with("mock-service-name")
+        self.manager.deployment_strategy.remove.assert_called_once_with(app)
 
-        # Check that the correct notifications were sent
-        mock_user_notify.success.assert_any_call(f"OpenFactory application {app_uuid} shut down successfully")
+        mock_deregister_asset.assert_has_calls([
+            call(
+                "APP123-1",
+                ksqlClient=self.manager.ksql,
+                bootstrap_servers=self.manager.bootstrap_servers
+            ),
+            call(
+                "APP123-2",
+                ksqlClient=self.manager.ksql,
+                bootstrap_servers=self.manager.bootstrap_servers
+            ),
+        ])
 
-        # Ensure Prometheus target was deregistered
-        mock_deregister_prometheus_target.assert_called_once_with(
-            app_uuid,
-            ksqlClient=self.manager.ksql,
-            bootstrap_servers=self.manager.bootstrap_servers
-        )
+        mock_deregister_prometheus_target.assert_has_calls([
+            call(
+                "APP123-1",
+                ksqlClient=self.manager.ksql,
+                bootstrap_servers=self.manager.bootstrap_servers
+            ),
+            call(
+                "APP123-2",
+                ksqlClient=self.manager.ksql,
+                bootstrap_servers=self.manager.bootstrap_servers
+            ),
+        ])
 
-        # Ensure asset was deregistered
-        mock_deregister_asset.assert_called_once_with(
-            app_uuid,
-            ksqlClient=self.manager.ksql,
-            bootstrap_servers=self.manager.bootstrap_servers
-        )
+        self.assertEqual(mock_deregister_asset.call_count, 2)
+        self.assertEqual(mock_deregister_prometheus_target.call_count, 2)
 
-    @patch("openfactory.openfactory_manager.deregister_prometheus_target")
-    @patch("openfactory.openfactory_manager.Asset")
+        mock_user_notify.success.assert_called_once_with("OpenFactory application APP123 shut down successfully")
+
     @patch("openfactory.openfactory_manager.user_notify")
+    @patch("openfactory.openfactory_manager.deregister_prometheus_target")
     @patch("openfactory.openfactory_manager.deregister_asset")
-    def test_tear_down_application_deregisters_prometheus_target(
+    def test_tear_down_application_service_not_found(
         self,
         mock_deregister_asset,
-        mock_user_notify,
-        MockAsset,
-        mock_deregister_prometheus_target
+        mock_deregister_prometheus_target,
+        mock_user_notify
     ):
-        """ Metrics target should be deregistered when an application is torn down """
+        """ Test tear_down_application when the Docker service no longer exists """
 
-        mock_app_instance = MagicMock()
-        mock_app_instance.DockerService.value = "mock-service-name"
-        MockAsset.return_value = mock_app_instance
-
-        app_uuid = "app-uuid-123"
-
-        self.manager.tear_down_application(app_uuid)
-
-        mock_deregister_prometheus_target.assert_called_once_with(
-            app_uuid,
-            ksqlClient=self.manager.ksql,
-            bootstrap_servers=self.manager.bootstrap_servers
-        )
-
-    @patch("openfactory.openfactory_manager.deregister_prometheus_target")
-    @patch("openfactory.openfactory_manager.Asset")
-    @patch("openfactory.openfactory_manager.user_notify")
-    @patch("openfactory.openfactory_manager.deregister_asset")
-    def test_tear_down_application_no_docker_service_still_deregisters_prometheus_target(
-        self,
-        mock_deregister_asset,
-        mock_user_notify,
-        MockAsset,
-        mock_deregister_prometheus_target
-    ):
-        """ Metrics target should still be deregistered when the Docker service no longer exists """
-
-        mock_app_instance = MagicMock()
-        mock_app_instance.DockerService.value = "mock-service-name"
-        MockAsset.return_value = mock_app_instance
+        app = MagicMock()
+        app.uuid = "APP123"
+        app.replicas_uuid.return_value = ["APP123-1", "APP123-2"]
 
         self.manager.deployment_strategy.remove.side_effect = (
             docker.errors.NotFound("Service not found")
         )
 
-        app_uuid = "app-uuid-123"
+        self.manager.tear_down_application(app)
 
-        self.manager.tear_down_application(app_uuid)
+        self.manager.deployment_strategy.remove.assert_called_once_with(app)
 
-        mock_deregister_prometheus_target.assert_called_once_with(
-            app_uuid,
-            ksqlClient=self.manager.ksql,
-            bootstrap_servers=self.manager.bootstrap_servers
-        )
+        mock_deregister_asset.assert_has_calls([
+            call(
+                "APP123-1",
+                ksqlClient=self.manager.ksql,
+                bootstrap_servers=self.manager.bootstrap_servers
+            ),
+            call(
+                "APP123-2",
+                ksqlClient=self.manager.ksql,
+                bootstrap_servers=self.manager.bootstrap_servers
+            ),
+        ])
+
+        mock_deregister_prometheus_target.assert_has_calls([
+            call(
+                "APP123-1",
+                ksqlClient=self.manager.ksql,
+                bootstrap_servers=self.manager.bootstrap_servers
+            ),
+            call(
+                "APP123-2",
+                ksqlClient=self.manager.ksql,
+                bootstrap_servers=self.manager.bootstrap_servers
+            ),
+        ])
+
+        self.assertEqual(mock_deregister_asset.call_count, 2)
+        self.assertEqual(mock_deregister_prometheus_target.call_count, 2)
+
+        mock_user_notify.success.assert_called_once_with("OpenFactory application APP123 shut down successfully")
 
     @patch('openfactory.openfactory_manager.get_apps_from_config_file')
     @patch('openfactory.openfactory_manager.user_notify')
@@ -1638,67 +1643,38 @@ class TestOpenFactoryManager(unittest.TestCase):
         # Should not continue to loading apps
         mock_get_apps_from_config_file.assert_not_called()
 
+    @patch("openfactory.openfactory_manager.user_notify")
     @patch("openfactory.openfactory_manager.deregister_prometheus_target")
-    @patch("openfactory.openfactory_manager.Asset")
-    @patch("openfactory.openfactory_manager.user_notify")
     @patch("openfactory.openfactory_manager.deregister_asset")
-    def test_tear_down_application_no_docker_service(self, mock_deregister_asset, mock_user_notify, MockAsset, mock_deregister_prometheus_target):
-        """ Test tear_down_application when application is not deployed as a Docker service """
+    def test_tear_down_application_docker_api_error(
+        self,
+        mock_deregister_asset,
+        mock_deregister_prometheus_target,
+        mock_user_notify
+    ):
+        """ Test tear_down_application handles Docker API errors """
 
-        # Mock Asset instance and its DockerService value
-        mock_app_instance = MagicMock()
-        mock_app_instance.DockerService.value = "mock-service-name"
-        MockAsset.return_value = mock_app_instance
-
-        # Simulate missing Docker service
-        self.manager.deployment_strategy.remove.side_effect = (
-            docker.errors.NotFound("Service not found")
-        )
-
-        app_uuid = "app-uuid-123"
-
-        self.manager.tear_down_application(app_uuid)
-
-        # Ensure Prometheus target was deregistered
-        mock_deregister_prometheus_target.assert_called_once_with(
-            app_uuid,
-            ksqlClient=self.manager.ksql,
-            bootstrap_servers=self.manager.bootstrap_servers
-        )
-
-        # Ensure asset was deregistered
-        mock_deregister_asset.assert_any_call(
-            app_uuid,
-            ksqlClient=self.manager.ksql,
-            bootstrap_servers=self.manager.bootstrap_servers
-        )
-
-        # No success notification
-        mock_user_notify.assert_not_called()
-
-    @patch("openfactory.openfactory_manager.Asset")
-    @patch("openfactory.openfactory_manager.user_notify")
-    @patch("openfactory.openfactory_manager.deregister_asset")
-    def test_tear_down_application_docker_api_error(self, mock_deregister_asset, mock_user_notify, MockAsset):
-        """ Test tear_down_application handels Docker API errors """
-
-        # Mock Asset instance and its DockerService value
-        mock_app_instance = MagicMock()
-        mock_app_instance.DockerService.value = "mock-service-name"
-        MockAsset.return_value = mock_app_instance
+        app = MagicMock()
+        app.uuid = "APP123"
+        app.replicas_uuid.return_value = ["APP123-1", "APP123-2"]
 
         # Setup deployment_strategy.remove to raise APIError
-        self.manager.deployment_strategy.remove.side_effect = docker.errors.APIError("Docker error")
+        self.manager.deployment_strategy.remove.side_effect = (
+            docker.errors.APIError("Docker error")
+        )
 
         # Call the method to test
         with self.assertRaises(OFAException):
-            self.manager.tear_down_application('app-uuid-123')
+            self.manager.tear_down_application(app)
 
-        # Ensure deregister_asset was not called
+        self.manager.deployment_strategy.remove.assert_called_once_with(app)
+
+        # Ensure cleanup was not performed
         mock_deregister_asset.assert_not_called()
+        mock_deregister_prometheus_target.assert_not_called()
 
         # No success message
-        mock_user_notify.assert_not_called()
+        mock_user_notify.success.assert_not_called()
 
     @patch("openfactory.openfactory_manager.get_apps_from_config_file")
     @patch("openfactory.openfactory_manager.user_notify")
@@ -1734,9 +1710,12 @@ class TestOpenFactoryManager(unittest.TestCase):
         manager.tear_down_application = MagicMock()
 
         # Mock the YAML config file content
+        app1 = OpenFactoryAppSchema(uuid='app-uuid-1', image='app1-image', environment=None, uns=None)
+        app2 = OpenFactoryAppSchema(uuid='app-uuid-3', image='app2-image', environment=None, uns=None)
+
         mock_get_apps_from_config_file.return_value = {
-            'App1': OpenFactoryAppSchema(uuid='app-uuid-1', image='app1-image', environment=None, uns=None),
-            'App2': OpenFactoryAppSchema(uuid='app-uuid-3', image='app2-image', environment=None, uns=None)
+            'App1': app1,
+            'App2': app2
         }
 
         # Call the method
@@ -1747,7 +1726,7 @@ class TestOpenFactoryManager(unittest.TestCase):
         mock_user_notify.info.assert_any_call('App1:')
         mock_user_notify.info.assert_any_call('App2:')
         mock_user_notify.info.assert_any_call('No application app-uuid-3 deployed in OpenFactory')
-        manager.tear_down_application.assert_called_once_with('app-uuid-1')
+        manager.tear_down_application.assert_called_once_with(app1)
 
     @patch('openfactory.openfactory_manager.get_apps_from_config_file')
     @patch('openfactory.openfactory_manager.UNSSchema')


### PR DESCRIPTION
# Support replica-aware application teardown

## Summary

This PR refactors the application teardown workflow to correctly support replicated OpenFactory applications.

Previously, application teardown assumed that an application consisted of a single deployed service and a single registered asset. With support for replicated applications, teardown now removes all replicas and cleans up all associated OpenFactory metadata.

## Changes

### Application teardown

* Refactored `tear_down_application()` to accept an `OpenFactoryAppSchema` instead of an application UUID.
* Updated the deployment strategy interface to remove applications rather than individual UUIDs.
* Deregister all replica assets during teardown.
* Deregister all Prometheus targets associated with application replicas.
* Continue cleanup when the Docker service no longer exists (`docker.errors.NotFound`).
* Report successful shutdown using the application UUID.

### Deployment strategies

* Updated both Docker Swarm and local Docker deployment strategies to remove applications using the application schema.
* Local Docker removal continues to remove every replicated container belonging to the application.

### Configuration-based shutdown

* Updated `shut_down_apps_from_config_file()` to pass the complete application object to `tear_down_application()`.

### Prometheus Metrics Registry

* Updated Prometheus target registration to register one scrape target per application replica.
* Added a guard so registration is only performed for Docker deployments.

### Tests

* Refactored unit tests to use `OpenFactoryAppSchema` instead of application UUIDs where appropriate.
* Added tests covering:

  * multi-replica teardown,
  * Docker service not found during teardown,
  * Docker API errors,
  * non-Docker Prometheus registration,
  * replica-aware Prometheus registration.

## Benefits

* Correct cleanup of replicated OpenFactory applications.
* Removal of stale asset registrations after application shutdown.
* Removal of stale Prometheus scrape targets.
* More consistent deployment strategy API.
* More robust teardown workflow that tolerates already-removed Docker services.
