### PR TITLE
Publish UNAVAILABLE availability during application shutdown

### DIFF
--- a/openfactory/apps/ofaapp.py
+++ b/openfactory/apps/ofaapp.py
@@ -369,6 +369,7 @@ class OpenFactoryApp(Asset, metaclass=OpenFactoryAppMeta):
             return
 
         self._shutdown_completed = True
+        self.avail = 'UNAVAILABLE'
         deregister_asset(
             self.asset_uuid,
             ksqlClient=self.ksql,

--- a/tests/openfactory/apps/test_openfactoryapp.py
+++ b/tests/openfactory/apps/test_openfactoryapp.py
@@ -369,6 +369,16 @@ class TestOpenFactoryApp(unittest.TestCase):
         app.app_event_loop_stopped.assert_called_once()
         self.assertTrue(app._shutdown_completed)
 
+    def test_shutdown_sets_availability_to_unavailable(self):
+        """ Test shutdown() marks the app as unavailable """
+        app = OpenFactoryApp(
+            ksqlClient=self.ksql_mock,
+            bootstrap_servers="mock_bootstrap",
+            asset_router_url="mocked_asset_url"
+        )
+        app.shutdown()
+        self.assertEqual(app.avail.value, "UNAVAILABLE")
+
     def test_shutdown_after_signal_handler_is_noop(self):
         """ Verify shutdown() becomes a no-op after signal_handler already performed cleanup. """
         app = OpenFactoryApp(


### PR DESCRIPTION
# Publish `UNAVAILABLE` availability during application shutdown

## Summary

This PR updates `OpenFactoryApp.shutdown()` to publish a final availability state of `UNAVAILABLE` before deregistering the asset.

Previously, applications were deregistered without sending an explicit offline availability event, preventing subscribers from observing the application's final state.

## Changes

* Set `self.avail = "UNAVAILABLE"` in `OpenFactoryApp.shutdown()`.
* Add a unit test verifying that `shutdown()` updates the availability to `UNAVAILABLE`.

## Why

Publishing a final `UNAVAILABLE` event ensures downstream consumers receive an explicit notification that the application is shutting down before the asset is deregistered.

## Testing

* Added a unit test to verify `shutdown()` sets the availability to `UNAVAILABLE`.
* Existing shutdown tests continue to pass, including idempotency and cleanup behavior.
