### PR TITLE
Automatically expose Docker Swarm task metadata

### DIFF
--- a/openfactory/openfactory_deploy_strategy.py
+++ b/openfactory/openfactory_deploy_strategy.py
@@ -173,11 +173,20 @@ class SwarmDeploymentStrategy(OpenFactoryServiceDeploymentStrategy):
 
         See parent method for argument descriptions.
 
-        Note:
+        Notes:
             - ``image_pull_policy`` is currently ignored for Swarm deployments.
+            - Docker Swarm task metadata is automatically exposed to the container through
+            the ``SWARM_TASK_SLOT``, ``SWARM_TASK_ID``, ``SWARM_SERVICE_NAME``, and
+            ``SWARM_NODE_HOSTNAME`` environment variables.
             - When ``open_files`` is specified, the service is deployed with a ``nofile`` ulimit using identical soft and hard limits.
             - If ``open_files`` is not specified, the Docker Engine default file descriptor limit is used.
         """
+
+        # Docker Swarm Go template variables
+        env.append("SWARM_TASK_SLOT={{.Task.Slot}}")
+        env.append("SWARM_TASK_ID={{.Task.ID}}")
+        env.append("SWARM_SERVICE_NAME={{.Service.Name}}")
+        env.append("SWARM_NODE_HOSTNAME={{.Node.Hostname}}")
 
         container = ContainerSpec(
             image=image,
@@ -217,7 +226,7 @@ class SwarmDeploymentStrategy(OpenFactoryServiceDeploymentStrategy):
         Remove a Docker service from a Docker Swarm cluster.
 
         Args:
-            appliacation (OpenFactoryAppSchema): OpenFactory application to be removed.
+            application (OpenFactoryAppSchema): OpenFactory application to be removed.
         """
         service = dal.docker_client.services.get(application.uuid.lower())
         service.remove()

--- a/tests/openfactory/test_openfactory_deploy_strategy.py
+++ b/tests/openfactory/test_openfactory_deploy_strategy.py
@@ -35,8 +35,18 @@ class TestSwarmDeploymentStrategy(unittest.TestCase):
         args, kwargs = mock_docker_client.api.create_service.call_args
         task = args[0]
 
+        env = task["ContainerSpec"]["Env"]
+        expected = [
+            "ENV=prod",
+            "SWARM_TASK_SLOT={{.Task.Slot}}",
+            "SWARM_TASK_ID={{.Task.ID}}",
+            "SWARM_SERVICE_NAME={{.Service.Name}}",
+            "SWARM_NODE_HOSTNAME={{.Node.Hostname}}",
+        ]
+        for value in expected:
+            self.assertIn(value, env)
+
         self.assertEqual(task["ContainerSpec"]["Image"], "test-image")
-        self.assertEqual(task["ContainerSpec"]["Env"], ["ENV=prod"])
         self.assertEqual(task["ContainerSpec"]["Labels"], {"role": "web"})
         self.assertEqual(task["ContainerSpec"]["Command"], ["run"])
         self.assertEqual(task["Resources"]["Limits"]["NanoCPUs"], 500000000)


### PR DESCRIPTION
# Automatically expose Docker Swarm task metadata

## Summary

This PR automatically injects Docker Swarm task metadata into the environment of every service deployed through `SwarmDeploymentStrategy`.

The following environment variables are now available to applications at runtime:

* `SWARM_TASK_SLOT`
* `SWARM_TASK_ID`
* `SWARM_SERVICE_NAME`
* `SWARM_NODE_HOSTNAME`

These values are populated using Docker Swarm Go templates when the service is created.

## Motivation

Applications running in Docker Swarm may need to identify the current task, replica, service, or node for logging, diagnostics, or replica-specific behavior. Automatically exposing this metadata removes the need for users to configure these environment variables manually.

## Changes

* Automatically inject Swarm task metadata environment variables during service deployment.
* Update unit tests to verify that the injected environment variables are present while preserving user-provided environment variables.
* Document the new behavior in the `SwarmDeploymentStrategy.deploy()` docstring.

## Testing

* Added/updated unit tests to verify that:

  * User-supplied environment variables are preserved.
  * The expected Swarm environment variables are injected into the service environment.
