### PR TITLE
Enrich App UUID for replicated swarm services

### DIFF
--- a/docs/api/apps/index.rst
+++ b/docs/api/apps/index.rst
@@ -25,6 +25,40 @@ As such, it exposes:
 
 This module provides a declarative and structured way to define both.
 
+-------------------------------------------------------------------------------
+
+Application Identity
+~~~~~~~~~~~~~~~~~~~~
+
+Each OpenFactory App is assigned a UUID during deployment. The UUID is
+generated from the OpenFactory deployment configuration and made available to
+the application automatically.
+
+For applications deployed as replicated OpenFactory Apps, each replica is
+automatically assigned a unique App UUID. The configured App UUID is used as
+the base identifier, and each replica is assigned a consecutive suffix based
+on its replica index.
+
+For example:
+
++--------------------------------------+------------------+
+| Deployment                           | App UUID         |
++======================================+==================+
+| Single replica                       | ``my-app``       |
++--------------------------------------+------------------+
+| Replica 1 of 3                       | ``my-app-1``     |
++--------------------------------------+------------------+
+| Replica 2 of 3                       | ``my-app-2``     |
++--------------------------------------+------------------+
+| Replica 3 of 3                       | ``my-app-3``     |
++--------------------------------------+------------------+
+
+
+This ensures that every replica is registered as a distinct OpenFactory asset
+while preserving the configured application identity across all replicas.
+
+-------------------------------------------------------------------------------
+
 Declarative Attributes
 ~~~~~~~~~~~~~~~~~~~~~~
 Attributes are defined as class-level fields using subclasses of
@@ -143,7 +177,7 @@ When an app is instantiated:
       app.run()
 
 .. note::
-  - The application UUID is injected via the ``APP_UUID`` environment variable during deployment.
+  - The application UUID is injected during deployment.
   - The environment variables ``KSQLDB_URL`` and ``KAFKA_BROKER`` are
     automatically provided in cluster deployments. The default values can be used for local development.
   - Either ``main_loop`` or ``async_main_loop`` must be implemented by subclasses.

--- a/docs/guide/applications/definition.rst
+++ b/docs/guide/applications/definition.rst
@@ -47,7 +47,26 @@ Each application must define a unique identifier:
 
     uuid: app-scheduler
 
-This value is used by OpenFactory as Asset UUID.
+This value defines the base Asset UUID of the application and is used by
+OpenFactory during deployment.
+
+For applications deployed with multiple replicas, OpenFactory automatically
+enriches the configured UUID by appending a consecutive numeric suffix so that
+each replica is assigned a unique Asset UUID.
+
+For example:
+
++-------------------------+---------------------+
+| Deployment              | Asset UUID          |
++=========================+=====================+
+| Single replica          | ``app-scheduler``   |
++-------------------------+---------------------+
+| Replica 1 of 3          | ``app-scheduler-1`` |
++-------------------------+---------------------+
+| Replica 2 of 3          | ``app-scheduler-2`` |
++-------------------------+---------------------+
+| Replica 3 of 3          | ``app-scheduler-3`` |
++-------------------------+---------------------+
 
 Image
 -----

--- a/openfactory/apps/ofaapp.py
+++ b/openfactory/apps/ofaapp.py
@@ -103,7 +103,10 @@ class OpenFactoryApp(Asset, metaclass=OpenFactoryAppMeta):
 
     Note:
       - When deployed on the OpenFactory Cluster, the environment variables ``KSQLDB_URL``, ``KAFKA_BROKER`` and ``ASSET_ROUTER_URL`` are set and can be used.
-      - The ``UUID`` of the App is set based on the OpenFactory configuration file of the App during the deployment process.
+      - The UUID of the App is set based on the OpenFactory configuration file
+        during the deployment process. If the App is deployed as a replicated
+        swarm service, the ``SWARM_TASK_SLOT`` is appended to the configured
+        UUID to ensure each replica has a unique asset UUID.
       - Subclasses must implement either :meth:`main_loop` (synchronous) or :meth:`async_main_loop` (asynchronous) to define application behavior.
       - Attributes are automatically added to the OpenFactory asset for version, manufacturer, license, and availability.
       - Use :meth:`OpenFactoryLogger.with_context <openfactory.logging.loggers.OpenFactoryLogger.with_context>` to create loggers
@@ -145,6 +148,10 @@ class OpenFactoryApp(Asset, metaclass=OpenFactoryAppMeta):
             test_mode (bool): If True, disables live Kafka/ksql interaction (useful for unit tests).
 
         Note:
+            - The application UUID is read from the ``APP_UUID`` environment
+              variable. When running as a replicated swarm service
+              (``SWARM_REPLICAS > 1``), the ``SWARM_TASK_SLOT`` is appended to the
+              application UUID so each replica is registered as a unique asset.
             - If ``bootstrap_servers`` is not explicitly provided, the constructor will attempt to read it from the ``KAFKA_BROKER`` environment variable.
             - If ``asset_router_url`` is not explicitly provided, the constructor will attempt to read it from the ``ASSET_ROUTER_URL`` environment variable.
             - Configures the application logger.
@@ -161,7 +168,13 @@ class OpenFactoryApp(Asset, metaclass=OpenFactoryAppMeta):
            The environment variables ``KSQLDB_URL``, ``KAFKA_BROKER`` and ``ASSET_ROUTER_URL`` will be set when deployed on the OpenFactory Cluster.
         """
         # get APP-UUID from environment (set during deployement by ofa deployment tool)
+        # add task slot in case of a replicated swarm service
         app_uuid = os.getenv('APP_UUID', 'DEV-UUID')
+        swarm_task_slot = os.getenv('SWARM_TASK_SLOT', None)
+        swarm_replicas = int(os.getenv('SWARM_REPLICAS', "1"))
+        if swarm_replicas > 1:
+            app_uuid = f"{app_uuid}-{swarm_task_slot}"
+
         super().__init__(asset_uuid=app_uuid, ksqlClient=ksqlClient,
                          bootstrap_servers=bootstrap_servers, asset_router_url=asset_router_url,
                          test_mode=test_mode)

--- a/openfactory/openfactory_deploy_strategy.py
+++ b/openfactory/openfactory_deploy_strategy.py
@@ -173,7 +173,7 @@ class SwarmDeploymentStrategy(OpenFactoryServiceDeploymentStrategy):
 
         See parent method for argument descriptions.
 
-        Notes:
+        Note:
             - ``image_pull_policy`` is currently ignored for Swarm deployments.
             - Docker Swarm task metadata is automatically exposed to the container through
             the ``SWARM_TASK_SLOT``, ``SWARM_TASK_ID``, ``SWARM_SERVICE_NAME``, and
@@ -187,6 +187,9 @@ class SwarmDeploymentStrategy(OpenFactoryServiceDeploymentStrategy):
         env.append("SWARM_TASK_ID={{.Task.ID}}")
         env.append("SWARM_SERVICE_NAME={{.Service.Name}}")
         env.append("SWARM_NODE_HOSTNAME={{.Node.Hostname}}")
+
+        replicas = mode.get("Replicated", {}).get("Replicas", 1) if mode else 1
+        env.append(f"SWARM_REPLICAS={replicas}")
 
         container = ContainerSpec(
             image=image,
@@ -347,7 +350,7 @@ class LocalDockerDeploymentStrategy(OpenFactoryServiceDeploymentStrategy):
 
         See parent method for argument descriptions.
 
-        Notes:
+        Note:
             - ``constraints`` are ignored for local containers.
             - ``mode["Replicated"]["Replicas"]`` determines the number of local containers to create.
             - Replicated containers are named ``<name>-1``, ``<name>-2``, ... and receive matching ``APP_UUID`` environment variables.

--- a/tests/openfactory/apps/test_openfactoryapp.py
+++ b/tests/openfactory/apps/test_openfactoryapp.py
@@ -63,6 +63,40 @@ class TestOpenFactoryApp(unittest.TestCase):
         from openfactory.assets import Asset
         self.assertTrue(issubclass(OpenFactoryApp, Asset), "OpenFactoryApp should derive from Asset")
 
+    def test_initialization_with_replicated_swarm_service(self):
+        """ App UUID is enriched with the swarm task slot for replicated services. """
+
+        with patch.dict(os.environ, {
+            "APP_UUID": "env-uuid",
+            "SWARM_REPLICAS": "2",
+            "SWARM_TASK_SLOT": "3",
+        }):
+            app = OpenFactoryApp(
+                ksqlClient=self.ksql_mock,
+                bootstrap_servers="mocked_broker",
+                asset_router_url="mocked_asset_url",
+                test_mode=True,
+            )
+
+        self.assertEqual(app.asset_uuid, "env-uuid-3")
+
+    def test_initialization_with_single_replica_keeps_uuid(self):
+        """ App UUID is unchanged for a single replica. """
+
+        with patch.dict(os.environ, {
+            "APP_UUID": "env-uuid",
+            "SWARM_REPLICAS": "1",
+            "SWARM_TASK_SLOT": "3",
+        }):
+            app = OpenFactoryApp(
+                ksqlClient=self.ksql_mock,
+                bootstrap_servers="mocked_broker",
+                asset_router_url="mocked_asset_url",
+                test_mode=True,
+            )
+
+        self.assertEqual(app.asset_uuid, "env-uuid")
+
     def test_initialization_with_env_vars(self):
         """ Test initialization with external environment variables set """
 

--- a/tests/openfactory/test_openfactory_deploy_strategy.py
+++ b/tests/openfactory/test_openfactory_deploy_strategy.py
@@ -42,6 +42,7 @@ class TestSwarmDeploymentStrategy(unittest.TestCase):
             "SWARM_TASK_ID={{.Task.ID}}",
             "SWARM_SERVICE_NAME={{.Service.Name}}",
             "SWARM_NODE_HOSTNAME={{.Node.Hostname}}",
+            "SWARM_REPLICAS=2",
         ]
         for value in expected:
             self.assertIn(value, env)


### PR DESCRIPTION
# Enrich App UUID for replicated swarm services

## Summary

This PR updates `OpenFactoryApp` to automatically enrich the configured App UUID when deployed as a replicated Docker Swarm service. Each replica now receives a unique asset UUID by appending the swarm task slot to the configured UUID.

## Motivation

The App UUID is generated from the OpenFactory configuration during deployment and uniquely identifies an application. When a service is deployed with multiple replicas, all instances previously shared the same UUID, preventing them from being registered as distinct assets.

This change preserves the configured UUID while ensuring each replica is assigned a unique asset UUID.

## Changes

- Append `SWARM_TASK_SLOT` to the configured `APP_UUID` when `SWARM_REPLICAS > 1`.
- Keep the App UUID unchanged for single-replica deployments.
- Add unit tests covering both single- and multi-replica deployments.
- Update the documentation to describe how App UUIDs are derived and enriched for replicated deployments.

## Example

| Deployment | App UUID |
|------------|----------|
| Single replica | `my-app` |
| Replica 1/3 | `my-app-1` |
| Replica 2/3 | `my-app-2` |
| Replica 3/3 | `my-app-3` |

## Testing

- Added unit test verifying that replicated deployments append the swarm task slot.
- Added unit test verifying that single-replica deployments preserve the configured UUID.
- Existing test suite passes.